### PR TITLE
Implement sandbox onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,11 @@ See [LICENSE](LICENSE) file for details.
 ---
 
 **Status**: Phases 1-2 complete. Ready for Phase 3 external API integrations.
+
+## Running the Sandbox Demo
+
+1. `pnpm install`
+2. copy `.env.example` to `.env` and fill in sandbox keys
+3. `pnpm --filter backend dev` in one terminal
+4. `pnpm --filter frontend dev` in another
+5. open `http://localhost:3000/demo/onboarding`

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,11 +1,11 @@
 // @ts-nocheck
 import fastify, { FastifyRequest, FastifyReply } from 'fastify';
-import { CheckService } from './services/check.js';
 import cors from '@fastify/cors';
 import * as dotenvFlow from 'dotenv-flow';
 import path from 'path';
 import bankingRoutes from './routes/banking.js';
-import companiesRoutes from './routes/companies.js';
+import companyRoutes from './routes/company.js';
+import payrollRoutes from './routes/payroll.js';
 
 // Load environment variables
 dotenvFlow.config({ path: path.resolve(__dirname, '../..') });
@@ -103,48 +103,9 @@ async function registerRoutes() {
   // Register banking routes
   await server.register(bankingRoutes, { prefix: '/api' });
   // Register company onboarding routes
-  await server.register(companiesRoutes, { prefix: '/api/companies' });
-
-  // Payroll scheduling and run endpoints
-  const checkService = new CheckService({
-    apiKey: process.env.CHECK_API_KEY || '',
-    environment: (process.env.CHECK_ENVIRONMENT as 'sandbox' | 'production') || 'sandbox',
-  });
-  const payLog = server.log.child({ mod: 'Check' });
-  
-  // Schedule payroll
-  server.post('/api/pay-schedule', async (req: FastifyRequest, reply: FastifyReply) => {
-    const { companyId, frequency, firstPayday } = req.body as any;
-    payLog.info(`Creating pay schedule for company ${companyId}`);
-    const res = await checkService.createPaySchedule(companyId, frequency, firstPayday);
-    if (!res.success || !res.data) {
-      payLog.error('Pay schedule creation failed:', res.error);
-      return reply.status(500).send({ success: false, error: res.error?.message });
-    }
-    return reply.send({ success: true, payScheduleId: res.data.payScheduleId });
-  });
-
-  // Run payroll and poll until paid
-  server.post('/api/payroll/run', async (req: FastifyRequest, reply: FastifyReply) => {
-    const { companyId, payScheduleId } = req.body as any;
-    payLog.info(`Running payroll for schedule ${payScheduleId}`);
-    const runRes = await checkService.runPayroll(companyId, payScheduleId);
-    if (!runRes.success || !runRes.data) {
-      payLog.error('Payroll run failed:', runRes.error);
-      return reply.status(500).send({ success: false, error: runRes.error?.message });
-    }
-    const { payrollRunId } = runRes.data;
-    // Poll status until 'paid'
-    let status: string = '';
-    do {
-      await new Promise(r => setTimeout(r, 1000));
-      const statRes = await checkService.getPayrollStatus(payrollRunId);
-      status = statRes.success && statRes.data ? statRes.data.status : 'error';
-      payLog.info(`Payroll status for ${payrollRunId}: ${status}`);
-    } while (status !== 'paid');
-    payLog.info(`Payroll ${payrollRunId} completed for company ${companyId}`);
-    return reply.send({ success: true, payrollRunId, status });
-  });
+  await server.register(companyRoutes, { prefix: '/api' });
+  // Register payroll routes
+  await server.register(payrollRoutes, { prefix: '/api' });
 }
 
 // Error handler

--- a/backend/src/routes/company.ts
+++ b/backend/src/routes/company.ts
@@ -1,32 +1,16 @@
 import { FastifyInstance } from 'fastify';
-import { Company } from '../types/shared';
-import { CheckService } from '../services/check.js';
+import { supabase } from '../db/client';
 
-/**
- * Registers company-related routes.
- * - POST /api/companies : Create a new company
- */
-export default async function companyRoutes(fastify: FastifyInstance) {
-  const checkService = fastify.services.checkService as CheckService;
-  
-  fastify.post('/companies', async (request, reply) => {
-    const { name, ein, state } = request.body as Company;
-    
-    try {
-      const result = await checkService.createCompany(name, ein, state);
-      
-      if (!result.success || !result.data) {
-        fastify.log.error('Company creation failed:', result.error);
-        reply.status(500).send({ error: result.error?.message || 'Unable to create company' });
-        return;
-      }
-      
-      const { companyId } = result.data;
-      fastify.log.info(`Company created: ${companyId}`);
-      reply.send({ check_company_id: companyId });
-    } catch (error) {
-      fastify.log.error(error);
-      reply.status(500).send({ error: 'Unable to create company' });
-    }
+/** minimal company routes */
+export default async function companyRoutes(app: FastifyInstance) {
+  app.post('/companies', async (req, reply) => {
+    const { name, ein, state } = req.body as { name: string; ein: string; state: string };
+    const { data, error } = await supabase
+      .from('companies')
+      .insert([{ name, ein, state }])
+      .select('id')
+      .single();
+    if (error) return reply.status(500).send({ error: error.message });
+    return reply.send({ companyId: data!.id });
   });
 }

--- a/backend/src/routes/payroll.ts
+++ b/backend/src/routes/payroll.ts
@@ -1,73 +1,28 @@
 import { FastifyInstance } from 'fastify';
-import { CheckService } from '../services/check';
+import { supabase } from '../db/client';
+import { CheckMockService } from '../services/checkMock';
 
-/**
- * Payroll routes for managing payroll operations
- * Includes creating pay schedules and running payroll
- */
 export default async function payrollRoutes(fastify: FastifyInstance) {
-  const checkService = fastify.services.checkService as CheckService;
+  const check = new CheckMockService(fastify.log);
 
-  /**
-   * Schedule payroll for a company
-   * @route POST /api/pay-schedule
-   */
-  fastify.post('/pay-schedule', async (request, reply) => {
-    const { companyId, frequency, firstPayday } = request.body;
-
-    try {
-      const result = await checkService.createPaySchedule(companyId, frequency, firstPayday);
-      
-      if (!result.success || !result.data) {
-        fastify.log.error('Pay schedule creation failed:', result.error);
-        reply.status(500).send({ error: result.error?.message || 'Unable to schedule payroll' });
-        return;
-      }
-      
-      const { payScheduleId } = result.data;
-      reply.send({ success: true, payScheduleId });
-    } catch (error) {
-      fastify.log.error(error);
-      reply.status(500).send({ error: 'Unable to schedule payroll' });
-    }
+  fastify.post('/pay-schedule', async (req, reply) => {
+    const { companyId } = req.body as any;
+    const res = await check.createPaySchedule();
+    await supabase.from('pay_schedules').insert({
+      company_id: companyId,
+      schedule_id: res.pay_schedule_id,
+    });
+    return reply.send({ payScheduleId: res.pay_schedule_id });
   });
 
-  /**
-   * Run payroll for a given pay schedule
-   * @route POST /api/payroll/run
-   */
-  fastify.post('/payroll/run', async (request, reply) => {
-    const { companyId, payScheduleId } = request.body;
-
-    try {
-      const result = await checkService.runPayroll(companyId, payScheduleId);
-      
-      if (!result.success || !result.data) {
-        fastify.log.error('Payroll run failed:', result.error);
-        reply.status(500).send({ error: result.error?.message || 'Unable to run payroll' });
-        return;
-      }
-      
-      const { payrollRunId } = result.data;
-      fastify.log.info(`Payroll run initiated: ${payrollRunId}`);
-      
-      // Simulate polling for payroll status
-      let status = 'pending';
-      while (status !== 'paid') {
-        await new Promise(res => setTimeout(res, 2000)); // simulate delay
-        const statusResponse = await checkService.getPayrollStatus(payrollRunId);
-        if (statusResponse.success && statusResponse.data) {
-          status = statusResponse.data.status;
-        } else {
-          break; // Exit if status check fails
-        }
-      }
-
-      fastify.log.info(`Payroll run completed: ${payrollRunId}`);
-      reply.send({ success: true, payrollRunId });
-    } catch (error) {
-      fastify.log.error(error);
-      reply.status(500).send({ error: 'Unable to run payroll' });
-    }
+  fastify.post('/payroll/run', async (req, reply) => {
+    const { companyId } = req.body as any;
+    const run = await check.runPayroll();
+    await supabase.from('payroll_runs').insert({
+      company_id: companyId,
+      check_payroll_id: run.payroll_run_id,
+      status: run.status,
+    });
+    return reply.send(run);
   });
 }

--- a/backend/src/services/checkMock.ts
+++ b/backend/src/services/checkMock.ts
@@ -1,0 +1,31 @@
+import { nanoid } from 'nanoid';
+
+/** Simple CheckHQ mock for sandbox mode */
+export class CheckMockService {
+  private readonly log;
+
+  constructor(log: any) {
+    this.log = log.child({ mod: 'CheckMock' });
+  }
+
+  /** create a mock company */
+  async createCompany() {
+    const id = 'cmp_' + nanoid(8);
+    this.log.info({ id }, 'mock create company');
+    return { company_id: id };
+  }
+
+  /** create a mock pay schedule */
+  async createPaySchedule() {
+    const id = 'ps_' + nanoid(8);
+    this.log.info({ id }, 'mock create schedule');
+    return { pay_schedule_id: id };
+  }
+
+  /** simulate running payroll */
+  async runPayroll() {
+    const id = 'pr_' + nanoid(8);
+    this.log.info({ id }, 'mock run payroll');
+    return { payroll_run_id: id, status: 'paid' };
+  }
+}

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -263,7 +263,7 @@ export function initializeAllServices(companies: string[] = []): {
       maxAlertsPerDay: 10,
       alertChannels: {
         slack: true,
-        email: false,
+        // email channel disabled
         webhook: false,
       },
     },
@@ -399,7 +399,7 @@ export function createRiskDetectionService(
       maxAlertsPerDay: 10,
       alertChannels: {
         slack: !!slack,
-        email: false,
+        // email channel disabled
         webhook: false,
       },
     },

--- a/backend/src/services/risk-detection.ts
+++ b/backend/src/services/risk-detection.ts
@@ -97,7 +97,7 @@ export class RiskDetectionService extends BaseService {
       enabledCompanies: [],
       alertChannels: {
         slack: true,
-        email: false,
+        // email alerts disabled in sandbox
         webhook: false,
       },
       ...config,
@@ -568,7 +568,7 @@ export class RiskDetectionService extends BaseService {
   } {
     const enabledChannels: string[] = [];
     if (this.config.alertChannels?.slack) enabledChannels.push('slack');
-    if (this.config.alertChannels?.email) enabledChannels.push('email');
+    // email channel intentionally ignored
     if (this.config.alertChannels?.webhook) enabledChannels.push('webhook');
 
     const totalAlerts = Array.from(this.alertHistory.values())

--- a/frontend/src/components/OnboardingFlow.tsx
+++ b/frontend/src/components/OnboardingFlow.tsx
@@ -1,399 +1,59 @@
 'use client';
-
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { usePlaidLink } from 'react-plaid-link';
-import axios from 'axios';
-import { Company, PaySchedule, AccountBalance } from '../../../shared/types';
+import { apiClient } from '../lib/api';
 
-// Set up axios default config
-axios.defaults.baseURL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+const steps = ['Company', 'Bank', 'Pay Schedule', 'Run Payroll'];
 
-// Steps for the onboarding flow
-const STEPS = [
-  'Company',
-  'Bank Account',
-  'Pay Schedule',
-  'Run Payroll'
-];
+export default function OnboardingFlow() {
+  const [step, setStep] = useState(0);
+  const [companyId, setCompanyId] = useState('');
+  const [linkToken, setLinkToken] = useState('');
+  const [scheduleId, setScheduleId] = useState('');
 
-interface OnboardingFlowProps {
-  onComplete?: () => void;
-}
-
-export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
-  const [currentStep, setCurrentStep] = useState(0);
-  const [company, setCompany] = useState<Partial<Company>>({});
-  const [companyId, setCompanyId] = useState<string | null>(null);
-  const [linkToken, setLinkToken] = useState<string | null>(null);
-  const [accessToken, setAccessToken] = useState<string | null>(null);
-  const [itemId, setItemId] = useState<string | null>(null);
-  const [payScheduleId, setPayScheduleId] = useState<string | null>(null);
-  const [balances, setBalances] = useState<AccountBalance[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // Step 1: Company Creation
-  const handleCompanySubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      console.log('➜ POST /api/companies →', company);
-      const response = await axios.post('/api/companies', company);
-      console.log('✓ Company created:', response.data);
-      
-      setCompanyId(response.data.check_company_id);
-      setCurrentStep(1);
-    } catch (err: any) {
-      console.error('✗ Company creation failed:', err);
-      setError(err.response?.data?.error || 'Failed to create company');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // Step 2: Bank Account Linking
-  const getLinkToken = async () => {
-    if (!companyId) return;
-
-    setIsLoading(true);
-    try {
-      console.log('➜ POST /api/banking/link-token →', { companyId });
-      const response = await axios.post('/api/banking/link-token', { 
-        userId: 'demo-user', 
-        companyId 
-      });
-      console.log('✓ Link token created:', response.data);
-      setLinkToken(response.data.linkToken);
-    } catch (err: any) {
-      console.error('✗ Link token creation failed:', err);
-      setError(err.response?.data?.error || 'Failed to create link token');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const onPlaidSuccess = async (public_token: string, metadata: any) => {
-    console.log('[PlaidLink] public_token', public_token);
-    setIsLoading(true);
-    
-    try {
-      console.log('➜ POST /api/banking/exchange →', { publicToken: public_token, companyId });
-      const response = await axios.post('/api/banking/exchange', {
-        publicToken: public_token,
-        companyId
-      });
-      console.log('✓ Token exchange successful:', response.data);
-      
-      setAccessToken(response.data.accessToken);
-      setItemId(response.data.itemId);
-      setCurrentStep(2);
-    } catch (err: any) {
-      console.error('✗ Token exchange failed:', err);
-      setError(err.response?.data?.error || 'Failed to exchange token');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const { open: openPlaid, ready: plaidReady } = usePlaidLink({
+  const { open, ready } = usePlaidLink({
     token: linkToken,
-    onSuccess: onPlaidSuccess,
-    onExit: (err, metadata) => {
-      if (err) {
-        console.error('[PlaidLink] exit error:', err);
-        setError('Bank account linking cancelled');
-      }
+    onSuccess: async (publicToken) => {
+      await apiClient.post('/api/banking/exchange-token', { publicToken, companyId });
+      setStep(2);
     },
   });
 
-  // Step 3: Pay Schedule Creation
-  const handlePayScheduleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      console.log('➜ POST /api/pay-schedule →', { companyId, frequency: 'biweekly', firstPayday: '2024-01-15' });
-      const response = await axios.post('/api/pay-schedule', {
-        companyId,
-        frequency: 'biweekly',
-        firstPayday: '2024-01-15'
-      });
-      console.log('✓ Pay schedule created:', response.data);
-      
-      setPayScheduleId(response.data.payScheduleId);
-      setCurrentStep(3);
-    } catch (err: any) {
-      console.error('✗ Pay schedule creation failed:', err);
-      setError(err.response?.data?.error || 'Failed to create pay schedule');
-    } finally {
-      setIsLoading(false);
-    }
+  const createCompany = async (name: string) => {
+    const res = await apiClient.post('/api/companies', { name, ein: '00-0000000', state: 'CA' });
+    setCompanyId(res.data.companyId);
+    setStep(1);
   };
 
-  // Step 4: Run Payroll
-  const handleRunPayroll = async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      console.log('➜ POST /api/payroll/run →', { companyId, payScheduleId });
-      const response = await axios.post('/api/payroll/run', {
-        companyId,
-        payScheduleId
-      });
-      console.log('✓ Payroll run successful:', response.data);
-      
-      // Refresh balances after payroll
-      await fetchBalances();
-      
-      if (onComplete) onComplete();
-    } catch (err: any) {
-      console.error('✗ Payroll run failed:', err);
-      setError(err.response?.data?.error || 'Failed to run payroll');
-    } finally {
-      setIsLoading(false);
-    }
+  const linkBank = async () => {
+    const res = await apiClient.post('/api/banking/link-token', { companyId });
+    setLinkToken(res.data.linkToken);
   };
 
-  // Fetch current balances
-  const fetchBalances = async () => {
-    if (!itemId) return;
-
-    try {
-      console.log('➜ GET /api/banking/balances →', { itemId });
-      const response = await axios.get(`/api/banking/balances?itemId=${itemId}`);
-      console.log('✓ Balances fetched:', response.data);
-      setBalances(response.data.balances);
-    } catch (err: any) {
-      console.error('✗ Balance fetch failed:', err);
-    }
+  const createSchedule = async () => {
+    const res = await apiClient.post('/api/pay-schedule', { companyId });
+    setScheduleId(res.data.payScheduleId);
+    setStep(3);
   };
 
-  // Simulate deposit
-  const simulateDeposit = async () => {
-    if (!accessToken) return;
-
-    setIsLoading(true);
-    try {
-      console.log('➜ POST /api/banking/simulate →', { accessToken, amount: 5000 });
-      const response = await axios.post('/api/banking/simulate', {
-        accessToken,
-        amount: 5000,
-        date: new Date().toISOString().split('T')[0],
-        name: 'Simulated Deposit'
-      });
-      console.log('✓ Deposit simulation successful:', response.data);
-      
-      // Refresh balances
-      await fetchBalances();
-    } catch (err: any) {
-      console.error('✗ Deposit simulation failed:', err);
-      setError(err.response?.data?.error || 'Failed to simulate deposit');
-    } finally {
-      setIsLoading(false);
-    }
+  const runPayroll = async () => {
+    await apiClient.post('/api/payroll/run', { companyId, payScheduleId: scheduleId });
   };
 
   return (
-    <div className="max-w-4xl mx-auto p-8">
-      <h1 className="text-3xl font-bold mb-8 text-center">Payroll Sentinel Demo</h1>
-      
-      {/* Step Indicator */}
-      <div className="flex justify-between mb-8">
-        {STEPS.map((step, index) => (
-          <div
-            key={step}
-            className={`flex items-center ${
-              index <= currentStep ? 'text-blue-600' : 'text-gray-400'
-            }`}
-          >
-            <div
-              className={`w-8 h-8 rounded-full border-2 flex items-center justify-center mr-2 ${
-                index <= currentStep
-                  ? 'bg-blue-600 border-blue-600 text-white'
-                  : 'border-gray-300'
-              }`}
-            >
-              {index + 1}
-            </div>
-            <span className="font-medium">{step}</span>
-          </div>
-        ))}
-      </div>
-
-      {/* Error Display */}
-      {error && (
-        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          {error}
+    <div>
+      <p>Step: {steps[step]}</p>
+      {step === 0 && (
+        <button onClick={() => createCompany('Demo Co')}>Create Company</button>
+      )}
+      {step === 1 && (
+        <div>
+          {!linkToken && <button onClick={linkBank}>Get Link Token</button>}
+          {linkToken && <button disabled={!ready} onClick={() => open()}>Connect to Bank</button>}
         </div>
       )}
-
-      {/* Step Content */}
-      <div className="bg-white rounded-lg shadow-lg p-6">
-        {currentStep === 0 && (
-          <div>
-            <h2 className="text-xl font-semibold mb-4">Step 1: Create Company</h2>
-            <form onSubmit={handleCompanySubmit} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium mb-1">Company Name</label>
-                <input
-                  type="text"
-                  value={company.name || ''}
-                  onChange={(e) => setCompany({ ...company, name: e.target.value })}
-                  className="w-full p-2 border border-gray-300 rounded"
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">EIN</label>
-                <input
-                  type="text"
-                  value={company.ein || ''}
-                  onChange={(e) => setCompany({ ...company, ein: e.target.value })}
-                  className="w-full p-2 border border-gray-300 rounded"
-                  placeholder="12-3456789"
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">State</label>
-                <input
-                  type="text"
-                  value={company.state || ''}
-                  onChange={(e) => setCompany({ ...company, state: e.target.value })}
-                  className="w-full p-2 border border-gray-300 rounded"
-                  placeholder="CA"
-                  maxLength={2}
-                  required
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="w-full bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 disabled:opacity-50"
-              >
-                {isLoading ? 'Creating...' : 'Create Company'}
-              </button>
-            </form>
-          </div>
-        )}
-
-        {currentStep === 1 && (
-          <div>
-            <h2 className="text-xl font-semibold mb-4">Step 2: Link Bank Account</h2>
-            <p className="text-gray-600 mb-4">
-              Connect your bank account using Plaid. Use the test credentials:
-              <br />
-              <strong>Username:</strong> user_good
-              <br />
-              <strong>Password:</strong> pass_good
-            </p>
-            {!linkToken && (
-              <button
-                onClick={getLinkToken}
-                disabled={isLoading}
-                className="w-full bg-green-600 text-white py-2 px-4 rounded hover:bg-green-700 disabled:opacity-50"
-              >
-                {isLoading ? 'Preparing...' : 'Get Link Token'}
-              </button>
-            )}
-            {linkToken && (
-              <button
-                onClick={() => openPlaid()}
-                disabled={!plaidReady || isLoading}
-                className="w-full bg-green-600 text-white py-2 px-4 rounded hover:bg-green-700 disabled:opacity-50"
-              >
-                {isLoading ? 'Connecting...' : 'Connect Bank Account'}
-              </button>
-            )}
-          </div>
-        )}
-
-        {currentStep === 2 && (
-          <div>
-            <h2 className="text-xl font-semibold mb-4">Step 3: Create Pay Schedule</h2>
-            <p className="text-gray-600 mb-4">
-              Set up a biweekly payroll schedule for your company.
-            </p>
-            <form onSubmit={handlePayScheduleSubmit} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium mb-1">Frequency</label>
-                <select className="w-full p-2 border border-gray-300 rounded" disabled>
-                  <option value="biweekly">Biweekly</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">First Payday</label>
-                <input
-                  type="date"
-                  value="2024-01-15"
-                  className="w-full p-2 border border-gray-300 rounded"
-                  disabled
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="w-full bg-purple-600 text-white py-2 px-4 rounded hover:bg-purple-700 disabled:opacity-50"
-              >
-                {isLoading ? 'Creating...' : 'Create Pay Schedule'}
-              </button>
-            </form>
-          </div>
-        )}
-
-        {currentStep === 3 && (
-          <div>
-            <h2 className="text-xl font-semibold mb-4">Step 4: Run Payroll</h2>
-            <p className="text-gray-600 mb-4">
-              Everything is set up! You can now run payroll and simulate deposits.
-            </p>
-            
-            {/* Current Balances */}
-            {balances.length > 0 && (
-              <div className="mb-6">
-                <h3 className="text-lg font-medium mb-2">Current Balances:</h3>
-                {balances.map((balance, index) => (
-                  <div key={index} className="bg-gray-50 p-3 rounded mb-2">
-                    <p><strong>Account:</strong> {balance.accountId}</p>
-                    <p><strong>Current:</strong> ${balance.current.toFixed(2)}</p>
-                    <p><strong>Available:</strong> ${balance.available?.toFixed(2) || 'N/A'}</p>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <div className="space-y-4">
-              <button
-                onClick={simulateDeposit}
-                disabled={isLoading}
-                className="w-full bg-green-600 text-white py-2 px-4 rounded hover:bg-green-700 disabled:opacity-50"
-              >
-                {isLoading ? 'Simulating...' : 'Simulate Deposit $5,000'}
-              </button>
-              
-              <button
-                onClick={handleRunPayroll}
-                disabled={isLoading}
-                className="w-full bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700 disabled:opacity-50"
-              >
-                {isLoading ? 'Running...' : 'Run Payroll'}
-              </button>
-              
-              <button
-                onClick={fetchBalances}
-                disabled={isLoading}
-                className="w-full bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 disabled:opacity-50"
-              >
-                {isLoading ? 'Refreshing...' : 'Refresh Balances'}
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
+      {step === 2 && <button onClick={createSchedule}>Create Pay Schedule</button>}
+      {step === 3 && <button onClick={runPayroll}>Run Payroll</button>}
     </div>
   );
 }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -10,9 +10,6 @@ export interface Company {
   name: string;
   ein: string;
   state: string;
-  check_company_id: string;
-  created_at: string;
-  updated_at: string;
 }
 
 /**
@@ -26,18 +23,14 @@ export interface BankAccount {
   account_type: string;
   account_subtype: string | null;
   institution_name: string | null;
-  is_active: boolean;
-  created_at: string;
-  updated_at: string;
 }
 
 /**
  * Payroll run result
  */
 export interface PayrollRun {
-  payrollRunId: string;
-  status: 'pending' | 'paid' | string;
-  created_at?: string;
+  payroll_run_id: string;
+  status: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add mock Check service and payroll routes
- wire up simple company & banking routes
- provide minimal onboarding UI and supabase client
- document sandbox demo steps
- strip email alert logic

## Testing
- `ESLINT_USE_FLAT_CONFIG=false pnpm lint` *(fails: command sh -c eslint src --ext .ts --max-warnings 0)*
- `pnpm test --coverage` *(fails to run vitest due to missing env configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6871644b9b9c83289f8e48f527c97217