### PR TITLE
Fix env path detection for backend

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,11 +4,22 @@ import { CheckService } from './services/check.js';
 import cors from '@fastify/cors';
 import * as dotenvFlow from 'dotenv-flow';
 import path from 'path';
+import fs from 'fs';
+
+// ----- Environment Configuration -----
+// Attempt to load environment variables from either the project root or the
+// backend directory so local setups work regardless of where `.env` is placed.
+const backendEnvPath = path.resolve(__dirname, '..');
+const repoRootEnvPath = path.resolve(__dirname, '../..');
+const envPath = fs.existsSync(path.join(backendEnvPath, '.env'))
+  ? backendEnvPath
+  : repoRootEnvPath;
+
+dotenvFlow.config({ path: envPath });
+console.log(`Loaded environment variables from ${envPath}`);
+
 import bankingRoutes from './routes/banking.js';
 import companiesRoutes from './routes/companies.js';
-
-// Load environment variables
-dotenvFlow.config({ path: path.resolve(__dirname, '../..') });
 
 // Environment variable warnings
 if (process.env.NODE_ENV !== 'production') {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,19 @@ import rateLimit from '@fastify/rate-limit';
 import winston from 'winston';
 import * as dotenvFlow from 'dotenv-flow';
 import path from 'path';
+import fs from 'fs';
+
+// ----- Environment Configuration -----
+// Support `.env` either in the backend directory or at the project root.
+const backendEnvPath = path.resolve(__dirname, '..');
+const repoRootEnvPath = path.resolve(__dirname, '../..');
+const envPath = fs.existsSync(path.join(backendEnvPath, '.env'))
+  ? backendEnvPath
+  : repoRootEnvPath;
+
+dotenvFlow.config({ path: envPath });
+console.log(`Loaded environment variables from ${envPath}`);
+
 import { registerRoutes } from './routes/index.js';
 // import middlewarePlugin, { errorHandler } from './middleware';
 import { JobScheduler } from './services/jobScheduler.js';
@@ -13,9 +26,6 @@ import { RiskEngine } from './services/riskEngine.js';
 import { PlaidService } from './services/plaid.js';
 import { CheckService } from './services/check.js';
 import { SlackService } from './services/slack.js';
-
-// Load environment variables from project root .env files
-dotenvFlow.config({ path: path.resolve(__dirname, '../..') });
 
 // Initialize database service
 import { initializeDatabase } from './config/database.js';


### PR DESCRIPTION
## Summary
- load `.env` from either backend or repo root so configuration always works

## Testing
- `pnpm lint` *(fails: missing eslint.config.js)*
- `pnpm test --coverage` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871752ea504832882dfb6356743540f