### PR TITLE
Fix frontend alias paths

### DIFF
--- a/frontend/src/app/banking/page.tsx
+++ b/frontend/src/app/banking/page.tsx
@@ -1,5 +1,5 @@
-import DashboardLayout from '@/components/layout/dashboard-layout'
-import BankingDashboard from '@/components/banking/banking-dashboard'
+import DashboardLayout from '@frontend/components/layout/dashboard-layout'
+import BankingDashboard from '@frontend/components/banking/banking-dashboard'
 
 export default function BankingPage() {
   return (

--- a/frontend/src/app/cash-flow/page.tsx
+++ b/frontend/src/app/cash-flow/page.tsx
@@ -1,5 +1,5 @@
-import DashboardLayout from '@/components/layout/dashboard-layout'
-import CashFlowDashboard from '@/components/cash-flow/cash-flow-dashboard'
+import DashboardLayout from '@frontend/components/layout/dashboard-layout'
+import CashFlowDashboard from '@frontend/components/cash-flow/cash-flow-dashboard'
 
 export default function CashFlowPage() {
   return (

--- a/frontend/src/app/data/page.tsx
+++ b/frontend/src/app/data/page.tsx
@@ -1,5 +1,5 @@
-import DashboardLayout from '@/components/layout/dashboard-layout'
-import DataManagement from '@/components/data/data-management'
+import DashboardLayout from '@frontend/components/layout/dashboard-layout'
+import DataManagement from '@frontend/components/data/data-management'
 
 export default function DataPage() {
   return (

--- a/frontend/src/app/monitoring/page.tsx
+++ b/frontend/src/app/monitoring/page.tsx
@@ -1,5 +1,5 @@
-import DashboardLayout from '@/components/layout/dashboard-layout'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import DashboardLayout from '@frontend/components/layout/dashboard-layout'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
 import { Activity, Server, Database, Cpu, MemoryStick, Clock } from 'lucide-react'
 
 export default function MonitoringPage() {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,5 @@
-import DashboardLayout from '@/components/layout/dashboard-layout'
-import DashboardStatsCards from '@/components/dashboard/dashboard-stats'
+import DashboardLayout from '@frontend/components/layout/dashboard-layout'
+import DashboardStatsCards from '@frontend/components/dashboard/dashboard-stats'
 
 export default function Home() {
   return (

--- a/frontend/src/app/payroll/page.tsx
+++ b/frontend/src/app/payroll/page.tsx
@@ -1,5 +1,5 @@
-import DashboardLayout from '@/components/layout/dashboard-layout'
-import PayrollDashboard from '@/components/payroll/payroll-dashboard'
+import DashboardLayout from '@frontend/components/layout/dashboard-layout'
+import PayrollDashboard from '@frontend/components/payroll/payroll-dashboard'
 
 export default function PayrollPage() {
   return (

--- a/frontend/src/app/risk/page.tsx
+++ b/frontend/src/app/risk/page.tsx
@@ -1,5 +1,5 @@
-import DashboardLayout from '@/components/layout/dashboard-layout'
-import RiskDashboard from '@/components/risk/risk-dashboard'
+import DashboardLayout from '@frontend/components/layout/dashboard-layout'
+import RiskDashboard from '@frontend/components/risk/risk-dashboard'
 
 export default function RiskPage() {
   return (

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
-import DashboardLayout from '@/components/layout/dashboard-layout'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
+import DashboardLayout from '@frontend/components/layout/dashboard-layout'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
+import { Button } from '@frontend/components/ui/button'
 import { 
   Settings, 
   User, 

--- a/frontend/src/components/OnboardingFlow.tsx
+++ b/frontend/src/components/OnboardingFlow.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { usePlaidLink } from 'react-plaid-link';
 import axios from 'axios';
-import { Company, PaySchedule, AccountBalance } from '../../../shared/types';
+import { Company, PaySchedule, AccountBalance } from '@frontend/shared/types';
 
 // Set up axios default config
 axios.defaults.baseURL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';

--- a/frontend/src/components/banking/banking-dashboard-old.tsx
+++ b/frontend/src/components/banking/banking-dashboard-old.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { formatCurrency, formatDate, getStatusColor } from '@/lib/utils'
-import { api } from '@/lib/api'
-import { BankAccount, Transaction } from '@/types'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
+import { Button } from '@frontend/components/ui/button'
+import { formatCurrency, formatDate, getStatusColor } from '@frontend/lib/utils'
+import { api } from '@frontend/lib/api'
+import { BankAccount, Transaction } from '@frontend/types'
 import { 
   CreditCard, 
   Building, 

--- a/frontend/src/components/banking/banking-dashboard.tsx
+++ b/frontend/src/components/banking/banking-dashboard.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useState } from 'react'
 import { usePlaidLink } from 'react-plaid-link'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { formatCurrency, formatDate, getStatusColor } from '@/lib/utils'
-import { api } from '@/lib/api'
-import { BankAccount, Transaction } from '@/types'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
+import { Button } from '@frontend/components/ui/button'
+import { formatCurrency, formatDate, getStatusColor } from '@frontend/lib/utils'
+import { api } from '@frontend/lib/api'
+import { BankAccount, Transaction } from '@frontend/types'
 import { 
   CreditCard, 
   Building, 

--- a/frontend/src/components/cash-flow/cash-flow-dashboard.tsx
+++ b/frontend/src/components/cash-flow/cash-flow-dashboard.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { formatCurrency, formatDate } from '@/lib/utils'
-import { api } from '@/lib/api'
-import { CashFlowSummary, CashFlowProjection } from '@/types'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
+import { Button } from '@frontend/components/ui/button'
+import { formatCurrency, formatDate } from '@frontend/lib/utils'
+import { api } from '@frontend/lib/api'
+import { CashFlowSummary, CashFlowProjection } from '@frontend/types'
 import { 
   DollarSign, 
   TrendingUp, 

--- a/frontend/src/components/dashboard/dashboard-stats.tsx
+++ b/frontend/src/components/dashboard/dashboard-stats.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { formatCurrency, formatDate, getRiskColor } from '@/lib/utils'
-import { api } from '@/lib/api'
-import { DashboardStats } from '@/types'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
+import { formatCurrency, formatDate, getRiskColor } from '@frontend/lib/utils'
+import { api } from '@frontend/lib/api'
+import { DashboardStats } from '@frontend/types'
 import { 
   DollarSign, 
   TrendingDown, 

--- a/frontend/src/components/data/data-management.tsx
+++ b/frontend/src/components/data/data-management.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useState } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { api } from '@/lib/api'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
+import { Button } from '@frontend/components/ui/button'
+import { api } from '@frontend/lib/api'
 import { 
   Upload, 
   Database, 

--- a/frontend/src/components/data/employee-uploader.tsx
+++ b/frontend/src/components/data/employee-uploader.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
-import { api } from '@/lib/api'
+import { Button } from '@frontend/components/ui/button'
+import { api } from '@frontend/lib/api'
 import { Users, Upload, Download, Plus, Trash2, CheckCircle } from 'lucide-react'
 
 interface EmployeeUploaderProps {

--- a/frontend/src/components/data/mock-data-generator.tsx
+++ b/frontend/src/components/data/mock-data-generator.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useState } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { api } from '@/lib/api'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
+import { Button } from '@frontend/components/ui/button'
+import { api } from '@frontend/lib/api'
 import { 
   Database, 
   Shuffle, 

--- a/frontend/src/components/data/payroll-uploader.tsx
+++ b/frontend/src/components/data/payroll-uploader.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
+import { Button } from '@frontend/components/ui/button'
 import { DollarSign, Upload, Calendar, CheckCircle, Plus } from 'lucide-react'
 
 interface PayrollUploaderProps {

--- a/frontend/src/components/data/plaid-link.tsx
+++ b/frontend/src/components/data/plaid-link.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from 'react'
 import { usePlaidLink } from 'react-plaid-link'
-import { Button } from '@/components/ui/button'
-import { api } from '@/lib/api'
+import { Button } from '@frontend/components/ui/button'
+import { api } from '@frontend/lib/api'
 import { CreditCard, ExternalLink, CheckCircle, AlertCircle } from 'lucide-react'
 
 interface PlaidLinkProps {

--- a/frontend/src/components/layout/dashboard-layout.tsx
+++ b/frontend/src/components/layout/dashboard-layout.tsx
@@ -16,7 +16,7 @@ import {
   CreditCard,
   Database
 } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import { cn } from '@frontend/lib/utils'
 
 interface DashboardLayoutProps {
   children: ReactNode

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { formatCurrency, formatDate, getStatusColor } from '@/lib/utils'
-import { api } from '@/lib/api'
-import { PayrollRun, Employee } from '@/types'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
+import { Button } from '@frontend/components/ui/button'
+import { formatCurrency, formatDate, getStatusColor } from '@frontend/lib/utils'
+import { api } from '@frontend/lib/api'
+import { PayrollRun, Employee } from '@frontend/types'
 import { 
   Users, 
   DollarSign, 

--- a/frontend/src/components/risk/risk-dashboard.tsx
+++ b/frontend/src/components/risk/risk-dashboard.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { formatDateTime, getRiskColor } from '@/lib/utils'
-import { api } from '@/lib/api'
-import { RiskAssessment, RiskAlert } from '@/types'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
+import { Button } from '@frontend/components/ui/button'
+import { formatDateTime, getRiskColor } from '@frontend/lib/utils'
+import { api } from '@frontend/lib/api'
+import { RiskAssessment, RiskAlert } from '@frontend/types'
 import { 
   Shield, 
   AlertTriangle, 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
-import { cn } from "@/lib/utils"
+import { cn } from "@frontend/lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { cn } from "@/lib/utils"
+import { cn } from "@frontend/lib/utils"
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@frontend/*": ["./src/*"],
+      "@frontend/shared/*": ["../shared/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- update tsconfig to use `@frontend` alias
- update all frontend imports to use new alias

## Testing
- `pnpm --filter frontend type-check` *(fails: None of the selected packages has a "type-check" script)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871ad1c5cd88328a9b765e8c15bd65e