### PR TITLE
Add dark mode theme across frontend

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,26 +1,65 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --background: #1D1D1D;
+  --foreground: #EAEAEA;
+  --secondary-background: #2C2C2C;
+  --secondary-foreground: #B0B0B0;
+  --accent: #0077FF;
+  --highlight: #4CAF50;
+  --error: #FF5733;
+  --border: #444444;
+  --font-sans: var(--font-inter);
+  --font-heading: var(--font-poppins);
 }
 
 body {
-  background: var(--background);
+  background-color: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
+}
+
+h1, h2, h3 {
+  font-family: var(--font-heading);
+  color: var(--foreground);
+}
+
+button {
+  background-color: var(--accent);
+  color: #FFFFFF;
+  border: none;
+  border-radius: 5px;
+  padding: 12px 20px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #005BB5;
+}
+
+input,
+select,
+textarea {
+  background-color: var(--secondary-background);
+  color: var(--foreground);
+  border: 1px solid var(--border);
+  padding: 10px;
+  border-radius: 5px;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.alert-success {
+  background-color: var(--highlight);
+  color: #FFFFFF;
+}
+
+.alert-error {
+  background-color: var(--error);
+  color: #FFFFFF;
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,16 +1,18 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Poppins } from "next/font/google";
 import "./globals.css";
 import { CompanyProvider } from '@frontend/context/CompanyContext'
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
+  weight: ["400", "500", "700"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const poppins = Poppins({
+  variable: "--font-poppins",
   subsets: ["latin"],
+  weight: ["400", "500", "700"],
 });
 
 export const metadata: Metadata = {
@@ -26,7 +28,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased dark:bg-gray-900 dark:text-gray-100`}
+        className={`${inter.variable} ${poppins.variable} antialiased bg-[#1D1D1D] text-[#EAEAEA]`}
       >
         <CompanyProvider>{children}</CompanyProvider>
       </body>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,8 +6,8 @@ export default function Home() {
     <DashboardLayout>
       <div className="space-y-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-          <p className="text-gray-600">Welcome to Payroll Sentinel</p>
+          <h1 className="text-2xl font-bold text-[#EAEAEA]">Dashboard</h1>
+          <p className="text-[#B0B0B0]">Welcome to Payroll Sentinel</p>
         </div>
         <DashboardStatsCards />
       </div>

--- a/frontend/src/components/banking/banking-dashboard.tsx
+++ b/frontend/src/components/banking/banking-dashboard.tsx
@@ -162,8 +162,8 @@ export default function BankingDashboard() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Banking</h1>
-          <p className="text-gray-600">Manage bank accounts and transactions</p>
+          <h1 className="text-2xl font-bold text-[#EAEAEA]">Banking</h1>
+          <p className="text-[#B0B0B0]">Manage bank accounts and transactions</p>
         </div>
         <div className="flex gap-2">
           <Button 
@@ -201,7 +201,7 @@ export default function BankingDashboard() {
             <div className="text-2xl font-bold text-green-600">
               {formatCurrency(getTotalBalance())}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Across {accounts?.length || 0} accounts
             </p>
           </CardContent>
@@ -216,7 +216,7 @@ export default function BankingDashboard() {
             <div className="text-2xl font-bold text-blue-600">
               {formatCurrency(getTotalAvailable())}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Available to spend
             </p>
           </CardContent>
@@ -231,7 +231,7 @@ export default function BankingDashboard() {
             <div className="text-2xl font-bold text-green-600">
               {status?.connected ? 'Connected' : 'Disconnected'}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Last sync: {status?.lastSync ? formatDate(status.lastSync) : 'Never'}
             </p>
           </CardContent>
@@ -246,7 +246,7 @@ export default function BankingDashboard() {
             <div className="text-2xl font-bold text-purple-600">
               {transactions?.length || 0}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Transactions this month
             </p>
           </CardContent>
@@ -272,23 +272,23 @@ export default function BankingDashboard() {
               accounts.map(account => (
                 <div key={account.id} className="flex items-center justify-between p-4 border rounded dark:border-gray-700">
                   <div className="flex items-center gap-4">
-                    <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded">
-                      <CreditCard className="h-6 w-6 text-gray-600 dark:text-gray-300" />
+                    <div className="p-2 bg-[#2C2C2C] rounded">
+                      <CreditCard className="h-6 w-6 text-[#B0B0B0]" />
                     </div>
                     <div>
                       <div className="font-medium">{account.name}</div>
-                      <div className="text-sm text-gray-600 dark:text-gray-400">{account.institutionName}</div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400 capitalize">{account.type} account</div>
+                      <div className="text-sm text-[#B0B0B0]">{account.institutionName}</div>
+                      <div className="text-xs text-[#B0B0B0] capitalize">{account.type} account</div>
                     </div>
                   </div>
                   <div className="text-right">
                     <div className={`text-lg font-semibold ${account.balance >= 0 ? 'text-green-600' : 'text-red-600'}`}> 
                       {formatCurrency((account as any).balance)}
                     </div>
-                    <div className="text-sm text-gray-600 dark:text-gray-400">
+                    <div className="text-sm text-[#B0B0B0]">
                       Available: {formatCurrency((account as any).availableBalance)}
                     </div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                    <div className="text-xs text-[#B0B0B0]">
                       Updated: {formatDate((account as any).lastUpdated)}
                     </div>
                   </div>
@@ -310,12 +310,12 @@ export default function BankingDashboard() {
         <CardContent>
           <div className="space-y-4">
             {!transactions || transactions.length === 0 ? (
-              <div className="p-4 text-center text-gray-500 border rounded dark:border-gray-700">
+              <div className="p-4 text-center text-[#B0B0B0] border rounded dark:border-gray-700">
                 No recent transactions
               </div>
             ) : (
               transactions.map((transaction) => (
-                <div key={transaction.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
+                <div key={transaction.id} className="flex items-center justify-between p-3 bg-[#2C2C2C] rounded">
                   <div className="flex items-center gap-3">
                     <div className={`p-2 rounded ${transaction.type === 'credit' ? 'bg-green-100' : 'bg-red-100'}`}>
                       {transaction.type === 'credit' ? (
@@ -326,15 +326,15 @@ export default function BankingDashboard() {
                     </div>
                     <div>
                       <div className="font-medium">{transaction.description}</div>
-                      <div className="text-sm text-gray-600">{transaction.category}</div>
-                      <div className="text-xs text-gray-500">{formatDate(transaction.date)}</div>
+                      <div className="text-sm text-[#B0B0B0]">{transaction.category}</div>
+                      <div className="text-xs text-[#B0B0B0]">{formatDate(transaction.date)}</div>
                     </div>
                   </div>
                   <div className="text-right">
                     <div className={`font-semibold ${transaction.amount >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                       {transaction.amount >= 0 ? '+' : ''}{formatCurrency(transaction.amount)}
                     </div>
-                    <div className="text-xs text-gray-500">
+                    <div className="text-xs text-[#B0B0B0]">
                       Account: {accounts?.find(a => a.id === transaction.accountId)?.name || 'Unknown'}
                     </div>
                   </div>

--- a/frontend/src/components/cash-flow/cash-flow-dashboard.tsx
+++ b/frontend/src/components/cash-flow/cash-flow-dashboard.tsx
@@ -115,8 +115,8 @@ export default function CashFlowDashboard() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Cash Flow</h1>
-          <p className="text-gray-600">Monitor and forecast cash flow</p>
+          <h1 className="text-2xl font-bold text-[#EAEAEA]">Cash Flow</h1>
+          <p className="text-[#B0B0B0]">Monitor and forecast cash flow</p>
         </div>
         <Button 
           onClick={recalculateProjections} 
@@ -139,7 +139,7 @@ export default function CashFlowDashboard() {
             <div className="text-2xl font-bold text-green-600">
               {formatCurrency(summary?.currentBalance || 0)}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Available funds
             </p>
           </CardContent>
@@ -154,7 +154,7 @@ export default function CashFlowDashboard() {
             <div className="text-2xl font-bold text-blue-600">
               {formatCurrency(summary?.projectedBalance || 0)}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               30-day projection
             </p>
           </CardContent>
@@ -169,7 +169,7 @@ export default function CashFlowDashboard() {
             <div className="text-2xl font-bold text-red-600">
               {formatCurrency(summary?.burnRate || 0)}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Average monthly expenses
             </p>
           </CardContent>
@@ -184,7 +184,7 @@ export default function CashFlowDashboard() {
             <div className={`text-2xl font-bold ${runwayColor}`}>
               {summary?.runway?.toFixed(1) || '0.0'} months
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               At current burn rate
             </p>
           </CardContent>
@@ -305,16 +305,16 @@ export default function CashFlowDashboard() {
               { date: '2025-01-06', description: 'Software Subscriptions', amount: -2500, type: 'expense' },
               { date: '2025-01-05', description: 'Client Payment - XYZ Ltd', amount: 15000, type: 'income' }
             ].map((transaction, index) => (
-              <div key={index} className="flex items-center justify-between p-3 bg-gray-50 rounded">
+              <div key={index} className="flex items-center justify-between p-3 bg-[#2C2C2C] rounded">
                 <div>
                   <div className="font-medium">{transaction.description}</div>
-                  <div className="text-sm text-gray-600">{formatDate(transaction.date)}</div>
+                  <div className="text-sm text-[#B0B0B0]">{formatDate(transaction.date)}</div>
                 </div>
                 <div className="text-right">
                   <div className={`font-semibold ${transaction.amount > 0 ? 'text-green-600' : 'text-red-600'}`}>
                     {transaction.amount > 0 ? '+' : ''}{formatCurrency(transaction.amount)}
                   </div>
-                  <div className="text-sm text-gray-500 capitalize">{transaction.type}</div>
+                  <div className="text-sm text-[#B0B0B0] capitalize">{transaction.type}</div>
                 </div>
               </div>
             ))}

--- a/frontend/src/components/dashboard/dashboard-stats.tsx
+++ b/frontend/src/components/dashboard/dashboard-stats.tsx
@@ -183,7 +183,7 @@ export default function DashboardStatsCards() {
               <div className={`text-2xl font-bold ${card.color}`}>
                 {card.value}
               </div>
-              <p className="text-xs text-gray-600 mt-1">
+              <p className="text-xs text-[#B0B0B0] mt-1">
                 {card.description}
               </p>
             </CardContent>

--- a/frontend/src/components/data/data-management.tsx
+++ b/frontend/src/components/data/data-management.tsx
@@ -48,7 +48,7 @@ export default function DataManagement() {
                 <h1 className="text-2xl font-bold text-gray-900">
                     Data Management
                 </h1>
-                <p className="text-gray-600">
+                <p className="text-[#B0B0B0]">
                     Connect accounts, upload data, and manage your information
                 </p>
             </div>
@@ -138,7 +138,7 @@ export default function DataManagement() {
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                         <div className="p-4 border-2 border-dashed border-gray-300 rounded-lg text-center">
                                             <Upload className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-                                            <div className="text-sm text-gray-600 mb-2">
+                                            <div className="text-sm text-[#B0B0B0] mb-2">
                                                 Transaction History CSV
                                             </div>
                                             <input
@@ -159,7 +159,7 @@ export default function DataManagement() {
 
                                         <div className="p-4 border-2 border-dashed border-gray-300 rounded-lg text-center">
                                             <Upload className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-                                            <div className="text-sm text-gray-600 mb-2">
+                                            <div className="text-sm text-[#B0B0B0] mb-2">
                                                 Employee Directory CSV
                                             </div>
                                             <input
@@ -217,7 +217,7 @@ export default function DataManagement() {
                                                 <div className="font-medium">
                                                     Bank Accounts
                                                 </div>
-                                                <div className="text-sm text-gray-600">
+                                                <div className="text-sm text-[#B0B0B0]">
                                                     3 accounts connected
                                                 </div>
                                             </div>
@@ -237,7 +237,7 @@ export default function DataManagement() {
                                                 <div className="font-medium">
                                                     Employee Data
                                                 </div>
-                                                <div className="text-sm text-gray-600">
+                                                <div className="text-sm text-[#B0B0B0]">
                                                     12 employees loaded
                                                 </div>
                                             </div>
@@ -257,7 +257,7 @@ export default function DataManagement() {
                                                 <div className="font-medium">
                                                     Payroll History
                                                 </div>
-                                                <div className="text-sm text-gray-600">
+                                                <div className="text-sm text-[#B0B0B0]">
                                                     6 months of data
                                                 </div>
                                             </div>
@@ -277,7 +277,7 @@ export default function DataManagement() {
                                                 <div className="font-medium">
                                                     Accounting Software
                                                 </div>
-                                                <div className="text-sm text-gray-600">
+                                                <div className="text-sm text-[#B0B0B0]">
                                                     QuickBooks integration
                                                 </div>
                                             </div>

--- a/frontend/src/components/data/plaid-link.tsx
+++ b/frontend/src/components/data/plaid-link.tsx
@@ -99,11 +99,11 @@ export default function PlaidLinkComponent({ onSuccess }: PlaidLinkProps) {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-4 p-4 border rounded-lg bg-gray-50">
+      <div className="flex items-center gap-4 p-4 border rounded-lg bg-[#2C2C2C]">
         <CreditCard className="h-8 w-8 text-blue-600" />
         <div className="flex-1">
           <div className="font-medium">Connect Your Bank Account</div>
-          <div className="text-sm text-gray-600">
+          <div className="text-sm text-[#B0B0B0]">
             Securely connect your business bank accounts using Plaid
           </div>
         </div>
@@ -112,7 +112,7 @@ export default function PlaidLinkComponent({ onSuccess }: PlaidLinkProps) {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="p-4 border rounded-lg">
           <div className="font-medium mb-2">Production Connection</div>
-          <div className="text-sm text-gray-600 mb-3">
+          <div className="text-sm text-[#B0B0B0] mb-3">
             Connect your real bank accounts for live data
           </div>
           <Button 
@@ -126,7 +126,7 @@ export default function PlaidLinkComponent({ onSuccess }: PlaidLinkProps) {
 
         <div className="p-4 border rounded-lg">
           <div className="font-medium mb-2">Try Plaid Demo</div>
-          <div className="text-sm text-gray-600 mb-3">
+          <div className="text-sm text-[#B0B0B0] mb-3">
             Test the connection flow with Plaid's sandbox
           </div>
           <Button 

--- a/frontend/src/components/layout/dashboard-layout.tsx
+++ b/frontend/src/components/layout/dashboard-layout.tsx
@@ -38,14 +38,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const pathname = usePathname()
 
   return (
-    <div className="flex h-screen bg-gray-50">
+    <div className="flex h-screen bg-[#1D1D1D] text-[#EAEAEA]">
       {/* Mobile sidebar */}
       <div className={cn(
         "fixed inset-0 z-40 lg:hidden",
         sidebarOpen ? "block" : "hidden"
       )}>
         <div className="fixed inset-0 bg-gray-600 bg-opacity-75" onClick={() => setSidebarOpen(false)} />
-        <div className="relative flex w-full max-w-xs flex-col bg-white">
+        <div className="relative flex w-full max-w-xs flex-col bg-[#2C2C2C]">
           <div className="absolute right-0 top-0 -mr-12 pt-2">
             <button
               type="button"
@@ -60,16 +60,16 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       </div>
 
       {/* Desktop sidebar */}
-      <div className="hidden lg:fixed lg:inset-y-0 lg:flex lg:w-64 lg:flex-col">
+      <div className="hidden lg:fixed lg:inset-y-0 lg:flex lg:w-64 lg:flex-col bg-[#2C2C2C]">
         <Sidebar />
       </div>
 
       {/* Main content */}
       <div className="flex flex-1 flex-col lg:pl-64">
-        <div className="sticky top-0 z-10 flex h-16 flex-shrink-0 bg-white shadow">
+        <div className="sticky top-0 z-10 flex h-16 flex-shrink-0 bg-[#2C2C2C] shadow">
           <button
             type="button"
-            className="border-r border-gray-200 px-4 text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500 lg:hidden"
+            className="border-r border-[#444444] px-4 text-[#B0B0B0] focus:outline-none focus:ring-2 focus:ring-inset focus:ring-[#0077FF] lg:hidden"
             onClick={() => setSidebarOpen(true)}
           >
             <Menu className="h-6 w-6" />
@@ -77,8 +77,8 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           <div className="flex flex-1 justify-between px-4">
             <div className="flex flex-1">
               <div className="flex w-full md:ml-0">
-                <div className="relative w-full text-gray-400 focus-within:text-gray-600">
-                  <h1 className="text-xl font-semibold text-gray-900 py-4">
+                <div className="relative w-full text-[#B0B0B0] focus-within:text-[#EAEAEA]">
+                  <h1 className="text-xl font-semibold text-[#EAEAEA] py-4">
                     Payroll Sentinel
                   </h1>
                 </div>
@@ -87,7 +87,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
             <div className="ml-4 flex items-center md:ml-6">
               <button
                 type="button"
-                className="rounded-full bg-white p-1 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                className="rounded-full bg-[#2C2C2C] p-1 text-[#B0B0B0] hover:text-[#EAEAEA] focus:outline-none focus:ring-2 focus:ring-[#0077FF] focus:ring-offset-2"
               >
                 <Bell className="h-6 w-6" />
               </button>
@@ -108,11 +108,11 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
   function Sidebar() {
     return (
-      <div className="flex min-h-0 flex-1 flex-col bg-white">
+      <div className="flex min-h-0 flex-1 flex-col bg-[#2C2C2C]">
         <div className="flex flex-1 flex-col overflow-y-auto pt-5 pb-4">
           <div className="flex flex-shrink-0 items-center px-4">
-            <Shield className="h-8 w-8 text-indigo-600" />
-            <span className="ml-2 text-xl font-semibold text-gray-900">
+            <Shield className="h-8 w-8 text-[#0077FF]" />
+            <span className="ml-2 text-xl font-semibold text-[#EAEAEA]">
               Payroll Sentinel
             </span>
           </div>
@@ -125,14 +125,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                   href={item.href}
                   className={cn(
                     isActive
-                      ? 'bg-indigo-50 text-indigo-700'
-                      : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900',
+                      ? 'bg-[#0077FF]/20 text-[#0077FF]'
+                      : 'text-[#B0B0B0] hover:bg-[#2C2C2C] hover:text-[#EAEAEA]',
                     'group flex items-center px-2 py-2 text-sm font-medium rounded-md'
                   )}
                 >
                   <item.icon
                     className={cn(
-                      isActive ? 'text-indigo-500' : 'text-gray-400 group-hover:text-gray-500',
+                      isActive ? 'text-[#0077FF]' : 'text-[#B0B0B0] group-hover:text-[#EAEAEA]',
                       'mr-3 h-6 w-6'
                     )}
                   />

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -89,8 +89,8 @@ export default function PayrollDashboard() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Payroll</h1>
-          <p className="text-gray-600">Manage payroll runs and employees</p>
+          <h1 className="text-2xl font-bold text-[#EAEAEA]">Payroll</h1>
+          <p className="text-[#B0B0B0]">Manage payroll runs and employees</p>
         </div>
         <div className="flex gap-2">
           <Dialog open={open} onOpenChange={setOpen}>
@@ -106,7 +106,7 @@ export default function PayrollDashboard() {
                   <Button variant="ghost" size="sm">Close</Button>
                 </DialogClose>
               </div>
-              <p className="text-sm text-gray-600">TODO: employee form goes here.</p>
+              <p className="text-sm text-[#B0B0B0]">TODO: employee form goes here.</p>
             </DialogContent>
           </Dialog>
           <Button onClick={refreshData} className="flex items-center gap-2">
@@ -127,7 +127,7 @@ export default function PayrollDashboard() {
             <div className="text-2xl font-bold text-blue-600">
               {summary?.totalEmployees || 0}
             </div>
-            <p className="text-xs text-gray-600 mt-1">Total employees</p>
+            <p className="text-xs text-[#B0B0B0] mt-1">Total employees</p>
           </CardContent>
         </Card>
 
@@ -140,7 +140,7 @@ export default function PayrollDashboard() {
             <div className="text-2xl font-bold text-green-600">
               {summary ? formatCurrency(summary.monthlyPayroll) : '$0'}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Total monthly cost
             </p>
           </CardContent>
@@ -155,7 +155,7 @@ export default function PayrollDashboard() {
             <div className="text-2xl font-bold text-purple-600">
               {summary?.nextPayroll ? formatDate(summary.nextPayroll) : 'Not scheduled'}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Scheduled date
             </p>
           </CardContent>
@@ -170,7 +170,7 @@ export default function PayrollDashboard() {
             <div className="text-2xl font-bold text-yellow-600">
               {summary?.pendingRuns ?? 0}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Awaiting approval
             </p>
           </CardContent>
@@ -188,7 +188,7 @@ export default function PayrollDashboard() {
         <CardContent>
           <div className="space-y-4">
             {(payrollRuns?.data || []).length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
+              <div className="text-center py-8 text-[#B0B0B0]">
                 No payroll runs found
               </div>
             ) : (
@@ -201,10 +201,10 @@ export default function PayrollDashboard() {
                       </div>
                       <div className="font-medium">{run.payPeriod}</div>
                     </div>
-                    <div className="text-sm text-gray-600">
+                    <div className="text-sm text-[#B0B0B0]">
                       {formatCurrency(run.totalAmount)} for {run.employeeCount} employees
                     </div>
-                    <div className="text-xs text-gray-500 mt-1">
+                    <div className="text-xs text-[#B0B0B0] mt-1">
                       Scheduled: {formatDate(run.scheduledDate)}
                     </div>
                   </div>
@@ -251,16 +251,16 @@ export default function PayrollDashboard() {
         <CardContent>
           <div className="space-y-4">
             {(employees?.data || []).length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
+              <div className="text-center py-8 text-[#B0B0B0]">
                 No employees found
               </div>
             ) : (
               (employees?.data || []).map((employee: Employee) => (
-                <div key={employee.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
+                <div key={employee.id} className="flex items-center justify-between p-3 bg-[#2C2C2C] rounded">
                   <div className="flex-1">
                     <div className="font-medium">{employee.name}</div>
-                    <div className="text-sm text-gray-600">{employee.position}</div>
-                    <div className="text-xs text-gray-500">
+                    <div className="text-sm text-[#B0B0B0]">{employee.position}</div>
+                    <div className="text-xs text-[#B0B0B0]">
                       {employee.department} • Started {formatDate(employee.startDate)}
                     </div>
                   </div>

--- a/frontend/src/components/risk/risk-dashboard.tsx
+++ b/frontend/src/components/risk/risk-dashboard.tsx
@@ -147,8 +147,8 @@ export default function RiskDashboard() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Risk Analysis</h1>
-          <p className="text-gray-600">Monitor and assess financial risks</p>
+          <h1 className="text-2xl font-bold text-[#EAEAEA]">Risk Analysis</h1>
+          <p className="text-[#B0B0B0]">Monitor and assess financial risks</p>
         </div>
         <Button 
           onClick={triggerAssessment} 
@@ -171,7 +171,7 @@ export default function RiskDashboard() {
             <div className={`text-2xl font-bold ${riskLevelColor}`}>
               {riskStatus?.overallRisk?.charAt(0).toUpperCase() + riskStatus?.overallRisk?.slice(1)}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Risk Score: {riskStatus?.score}/100
             </p>
           </CardContent>
@@ -186,7 +186,7 @@ export default function RiskDashboard() {
             <div className="text-2xl font-bold text-yellow-600">
               {alerts.filter(a => !a.acknowledged).length}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               Unacknowledged alerts
             </p>
           </CardContent>
@@ -201,7 +201,7 @@ export default function RiskDashboard() {
             <div className="text-2xl font-bold text-blue-600">
               {riskStatus?.lastAssessment ? formatDateTime(riskStatus.lastAssessment).split(',')[0] : 'N/A'}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[#B0B0B0] mt-1">
               {riskStatus?.lastAssessment ? formatDateTime(riskStatus.lastAssessment).split(',')[1] : 'No recent assessment'}
             </p>
           </CardContent>
@@ -219,10 +219,10 @@ export default function RiskDashboard() {
         <CardContent>
           <div className="space-y-4">
             {riskStatus?.factors?.map((factor: any, index: number) => (
-              <div key={index} className="flex items-center justify-between p-3 bg-gray-50 rounded">
+              <div key={index} className="flex items-center justify-between p-3 bg-[#2C2C2C] rounded">
                 <div>
                   <div className="font-medium">{factor.category}</div>
-                  <div className="text-sm text-gray-600">Impact: {factor.impact}</div>
+                  <div className="text-sm text-[#B0B0B0]">Impact: {factor.impact}</div>
                 </div>
                 <div className="text-right">
                   <div className="font-semibold">{factor.score}/100</div>
@@ -247,7 +247,7 @@ export default function RiskDashboard() {
         <CardContent>
           <div className="space-y-4">
             {alerts.length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
+              <div className="text-center py-8 text-[#B0B0B0]">
                 No active alerts
               </div>
             ) : (
@@ -258,13 +258,13 @@ export default function RiskDashboard() {
                       <div className={`px-2 py-1 text-xs rounded ${getRiskColor(alert.level)}`}>
                         {alert.level}
                       </div>
-                      <div className="text-xs text-gray-500">
+                      <div className="text-xs text-[#B0B0B0]">
                         {alert.type.replace('_', ' ')}
                       </div>
                     </div>
                     <div className="font-medium">{alert.title}</div>
-                    <div className="text-sm text-gray-600 mt-1">{alert.description}</div>
-                    <div className="text-xs text-gray-500 mt-2">
+                    <div className="text-sm text-[#B0B0B0] mt-1">{alert.description}</div>
+                    <div className="text-xs text-[#B0B0B0] mt-2">
                       {formatDateTime(alert.timestamp)}
                     </div>
                   </div>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -7,15 +7,14 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-slate-900 text-slate-50 hover:bg-slate-900/90",
-        destructive:
-          "bg-red-500 text-slate-50 hover:bg-red-500/90",
+        default: "bg-[#0077FF] text-white hover:bg-[#005BB5]",
+        destructive: "bg-[#FF5733] text-white hover:bg-[#FF5733]/90",
         outline:
-          "border border-slate-200 bg-white hover:bg-slate-100 hover:text-slate-900",
+          "border border-[#444444] bg-[#2C2C2C] hover:bg-[#2C2C2C]/80 text-[#EAEAEA]",
         secondary:
-          "bg-slate-100 text-slate-900 hover:bg-slate-100/80",
-        ghost: "hover:bg-slate-100 hover:text-slate-900",
-        link: "text-slate-900 underline-offset-4 hover:underline",
+          "bg-[#2C2C2C] text-[#EAEAEA] hover:bg-[#2C2C2C]/80",
+        ghost: "hover:bg-[#2C2C2C] text-[#EAEAEA]",
+        link: "text-[#0077FF] underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border border-gray-200 bg-white text-gray-950 shadow-sm",
+      "rounded-lg border border-[#444444] bg-[#2C2C2C] text-[#EAEAEA] shadow-sm",
       className
     )}
     {...props}
@@ -49,7 +49,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-gray-600", className)}
+    className={cn("text-sm text-[#B0B0B0]", className)}
     {...props}
   />
 ))

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -43,7 +43,7 @@ export function getRiskColor(level: 'low' | 'medium' | 'high'): string {
     case 'high':
       return 'text-red-600 bg-red-50'
     default:
-      return 'text-gray-600 bg-gray-50'
+      return 'text-[#B0B0B0] bg-[#2C2C2C]'
   }
 }
 
@@ -62,6 +62,6 @@ export function getStatusColor(status: string): string {
     case 'disconnected':
       return 'text-red-600 bg-red-50'
     default:
-      return 'text-gray-600 bg-gray-50'
+      return 'text-[#B0B0B0] bg-[#2C2C2C]'
   }
 }


### PR DESCRIPTION
## Summary
- implement Inter and Poppins fonts
- overhaul global CSS for dark palette
- update layout for new fonts and colors
- tweak button and card components for dark mode
- adapt various pages and dashboards to dark styling

## Testing
- `pnpm lint` *(fails: no-unused-vars in backend)*
- `pnpm test --coverage` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e09ed7dc83288a1f64cb946bcc8a