### PR TITLE
Implement live payroll data fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+!backend/logs/SCHEMA_CHANGES.md
+!backend/logs/
+!backend/logs/SCHEMA_CHANGES.md

--- a/backend/logs/SCHEMA_CHANGES.md
+++ b/backend/logs/SCHEMA_CHANGES.md
@@ -1,0 +1,3 @@
+# Schema Changes
+
+- 2025-07-12T22:37:08+00:00 added employees.department and employees.start_date columns

--- a/backend/src/routes/payroll.ts
+++ b/backend/src/routes/payroll.ts
@@ -1,12 +1,94 @@
-import { FastifyInstance } from 'fastify';
-import { CheckService } from '@backend/services/check';
+import { FastifyInstance } from 'fastify'
+import { CheckService } from '@backend/services/check'
+import { supabase } from '@backend/db/client'
+import fs from 'fs'
 
 /**
  * Payroll routes for managing payroll operations
  * Includes creating pay schedules and running payroll
  */
 export default async function payrollRoutes(fastify: FastifyInstance) {
-  const checkService = fastify.services.checkService as CheckService;
+  const checkService = (fastify as any).services?.checkService
+    ? (fastify as any).services.checkService as CheckService
+    : new CheckService({
+        apiKey: process.env.CHECK_API_KEY || '',
+        environment:
+          (process.env.CHECK_ENVIRONMENT as 'sandbox' | 'production') || 'sandbox',
+      })
+
+  /** Ensure required tables exist. */
+  async function ensureSchema() {
+    try {
+      await supabase.from('employees').select('id').limit(1)
+    } catch (err: any) {
+      if (err?.message?.includes('relation') || err?.code === '42P01') {
+        await supabase.rpc('execute_sql', {
+          sql: `create table if not exists employees (
+            id uuid primary key default uuid_generate_v4(),
+            company_id uuid references companies(id) on delete cascade,
+            name text,
+            title text,
+            salary numeric,
+            status text,
+            department text,
+            start_date date,
+            created_at timestamp with time zone default now(),
+            updated_at timestamp with time zone default now()
+          );`
+        })
+        fs.appendFileSync(
+          'backend/logs/SCHEMA_CHANGES.md',
+          `- ${new Date().toISOString()} created employees table\n`
+        )
+      }
+    }
+    try {
+      await supabase.from('employees').select('department').limit(1)
+    } catch (err: any) {
+      if (err?.message?.includes('column') || err?.code === '42703') {
+        await supabase.rpc('execute_sql', {
+          sql: 'alter table employees add column if not exists department text;'
+        })
+        fs.appendFileSync(
+          'backend/logs/SCHEMA_CHANGES.md',
+          `- ${new Date().toISOString()} added employees.department column\n`
+        )
+      }
+    }
+    try {
+      await supabase.from('employees').select('start_date').limit(1)
+    } catch (err: any) {
+      if (err?.message?.includes('column') || err?.code === '42703') {
+        await supabase.rpc('execute_sql', {
+          sql: 'alter table employees add column if not exists start_date date;'
+        })
+        fs.appendFileSync(
+          'backend/logs/SCHEMA_CHANGES.md',
+          `- ${new Date().toISOString()} added employees.start_date column\n`
+        )
+      }
+    }
+    try {
+      await supabase.from('pay_schedules').select('id').limit(1)
+    } catch (err: any) {
+      if (err?.message?.includes('relation') || err?.code === '42P01') {
+        await supabase.rpc('execute_sql', {
+          sql: `create table if not exists pay_schedules (
+            id uuid primary key default uuid_generate_v4(),
+            company_id uuid references companies(id) on delete cascade,
+            frequency text,
+            next_run_date date,
+            created_at timestamp with time zone default now(),
+            updated_at timestamp with time zone default now()
+          );`
+        })
+        fs.appendFileSync(
+          'backend/logs/SCHEMA_CHANGES.md',
+          `- ${new Date().toISOString()} created pay_schedules table\n`
+        )
+      }
+    }
+  }
 
   /**
    * Schedule payroll for a company
@@ -37,10 +119,32 @@ export default async function payrollRoutes(fastify: FastifyInstance) {
    * @route POST /api/payroll/run
    */
   fastify.post('/payroll/run', async (request, reply) => {
-    const { companyId, payScheduleId } = request.body;
+    const { companyId, payScheduleId } = request.body as {
+      companyId: string;
+      payScheduleId?: string;
+    };
+
+    await ensureSchema();
 
     try {
-      const result = await checkService.runPayroll(companyId, payScheduleId);
+      let scheduleId = payScheduleId;
+      if (!scheduleId) {
+        const { data } = await supabase
+          .from('pay_schedules')
+          .select('id')
+          .eq('company_id', companyId)
+          .order('created_at', { ascending: true })
+          .limit(1)
+          .single();
+        if (!data) {
+          return reply
+            .status(400)
+            .send({ error: 'No pay schedule found for company' });
+        }
+        scheduleId = data.id as string;
+      }
+
+      const result = await checkService.runPayroll(companyId, scheduleId);
       
       if (!result.success || !result.data) {
         fastify.log.error('Payroll run failed:', result.error);
@@ -64,10 +168,141 @@ export default async function payrollRoutes(fastify: FastifyInstance) {
       }
 
       fastify.log.info(`Payroll run completed: ${payrollRunId}`);
-      reply.send({ success: true, payrollRunId });
+
+      // Persist basic run record for demo purposes
+      await supabase.from('payroll_runs').insert({
+        company_id: companyId,
+        check_payroll_id: payrollRunId,
+        pay_date: new Date().toISOString().split('T')[0],
+        total_amount: 0,
+        status,
+      });
+
+      reply.send({ success: true, payrollRunId, status });
     } catch (error) {
       fastify.log.error(error);
       reply.status(500).send({ error: 'Unable to run payroll' });
     }
   });
+
+  /**
+   * Get payroll summary for dashboard
+   * @route GET /api/payroll/summary
+   */
+  fastify.get('/payroll/summary', async (request, reply) => {
+    const start = Date.now()
+    const { companyId } = request.query as { companyId: string }
+    await ensureSchema()
+    try {
+      const { data: empRows } = await supabase
+        .from('employees')
+        .select('salary')
+        .eq('company_id', companyId)
+
+      const { data: scheduleRows } = await supabase
+        .from('pay_schedules')
+        .select('next_run_date')
+        .eq('company_id', companyId)
+        .order('next_run_date', { ascending: true })
+        .limit(1)
+
+      const { data: runRows } = await supabase
+        .from('payroll_runs')
+        .select('status')
+        .eq('company_id', companyId)
+
+      const totalEmployees = empRows?.length || 0
+      const monthlyPayroll =
+        (empRows?.reduce((t, e) => t + Number(e.salary || 0), 0) || 0) / 12
+      const nextPayroll = scheduleRows?.[0]?.next_run_date || null
+      const pendingRuns = runRows?.filter(r => r.status === 'pending').length || 0
+
+      fastify.log.info({ mod: 'Payroll' }, 'summary fetched in %d ms', Date.now() - start)
+      return reply.send({ totalEmployees, monthlyPayroll, nextPayroll, pendingRuns })
+    } catch (error) {
+      fastify.log.error({ mod: 'Payroll' }, 'summary error %o', error)
+      return reply.status(500).send({ error: 'failed to fetch summary' })
+    }
+  })
+
+  /**
+   * Get payroll runs
+   * @route GET /api/payroll/runs
+   */
+  fastify.get('/payroll/runs', async (request, reply) => {
+    const { companyId } = request.query as { companyId: string }
+    await ensureSchema()
+    try {
+      const { data, error } = await supabase
+        .from('payroll_runs')
+        .select('*')
+        .eq('company_id', companyId)
+        .order('pay_date', { ascending: false })
+      if (error) throw error
+      fastify.log.info({ mod: 'Payroll' }, 'runs fetched')
+      return reply.send({ data })
+    } catch (err) {
+      fastify.log.error({ mod: 'Payroll' }, 'runs error %o', err)
+      return reply.status(500).send({ error: 'failed to fetch runs' })
+    }
+  })
+
+  /**
+   * Get employees
+   * @route GET /api/payroll/employees
+   */
+  fastify.get('/payroll/employees', async (request, reply) => {
+    const { companyId } = request.query as { companyId: string }
+    await ensureSchema()
+    try {
+      const { data, error } = await supabase
+        .from('employees')
+        .select('*')
+        .eq('company_id', companyId)
+        .order('created_at', { ascending: true })
+      if (error) throw error
+      fastify.log.info({ mod: 'Payroll' }, 'employees fetched')
+      return reply.send({ data })
+    } catch (err) {
+      fastify.log.error({ mod: 'Payroll' }, 'employees error %o', err)
+      return reply.status(500).send({ error: 'failed to fetch employees' })
+    }
+  })
+
+  /**
+   * Add a new employee
+   * @route POST /api/payroll/employees
+   */
+  fastify.post('/payroll/employees', async (request, reply) => {
+    const {
+      companyId,
+      name,
+      title,
+      salary,
+      status,
+      department,
+      startDate,
+    } = request.body as any
+
+    await ensureSchema()
+
+    try {
+      const { error } = await supabase.from('employees').insert({
+        company_id: companyId,
+        name,
+        title,
+        salary,
+        status,
+        department,
+        start_date: startDate,
+      })
+      if (error) throw error
+      fastify.log.info({ mod: 'Payroll' }, 'employee added')
+      await reply.send({ success: true })
+    } catch (err) {
+      fastify.log.error({ mod: 'Payroll' }, 'add employee error %o', err)
+      return reply.status(500).send({ error: 'failed to add employee' })
+    }
+  })
 }
+

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -1,126 +1,60 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import useSWR from 'swr'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@frontend/components/ui/card'
 import { Button } from '@frontend/components/ui/button'
 import { formatCurrency, formatDate, getStatusColor } from '@frontend/lib/utils'
-import { api } from '@frontend/lib/api'
+import { api, apiClient } from '@frontend/lib/api'
 import { useCompany } from '@frontend/context/CompanyContext'
 import CompanySelector from '@frontend/components/CompanySelector'
-import { PayrollRun, Employee } from '@frontend/types'
-import { 
-  Users, 
-  DollarSign, 
-  Calendar, 
+import { PayrollRun } from '@frontend/types'
+import type { Employee } from '@frontend/shared/types'
+import {
+  Users,
+  DollarSign,
+  Calendar,
   CheckCircle,
   Clock,
   Play,
   RefreshCw
 } from 'lucide-react'
+import { Dialog, DialogTrigger, DialogContent, DialogClose } from '@frontend/components/ui/dialog'
+import { useState } from 'react'
 
 export default function PayrollDashboard() {
   const { companyId } = useCompany()
+  const [open, setOpen] = useState(false)
 
   if (!companyId) {
     return <CompanySelector />
   }
-  const [payrollRuns, setPayrollRuns] = useState<PayrollRun[]>([])
-  const [employees, setEmployees] = useState<Employee[]>([])
-  const [summary, setSummary] = useState<any>(null)
-  const [loading, setLoading] = useState(true)
+  const fetcher = (url: string) => apiClient.get(url).then(res => res.data)
 
-  useEffect(() => {
-    fetchPayrollData()
-  }, [])
+  const { data: payrollRuns, isLoading: loadingRuns, mutate: mutRuns } =
+    useSWR(() => `/api/payroll/runs?companyId=${companyId}`, fetcher, {
+      revalidateOnFocus: false,
+    })
+  const { data: employees, isLoading: loadingEmp, mutate: mutEmp } = useSWR(
+    () => `/api/payroll/employees?companyId=${companyId}`,
+    fetcher,
+    { revalidateOnFocus: false }
+  )
+  const { data: summary, isLoading: loadingSummary, mutate: mutSum } = useSWR(
+    () => `/api/payroll/summary?companyId=${companyId}`,
+    fetcher,
+    { revalidateOnFocus: false }
+  )
 
-  const fetchPayrollData = async () => {
-    try {
-      setLoading(true)
-      
-      let runsData = []
-      let employeesData = []
-      let summaryData = null
+  const loading = loadingRuns || loadingEmp || loadingSummary
 
-      try {
-        const [runsRes, employeesRes, summaryRes] = await Promise.all([
-          api.payroll.getRuns(companyId),
-          api.payroll.getEmployees(companyId),
-          api.payroll.getSummary(companyId)
-        ])
-
-        runsData = runsRes.data || []
-        employeesData = employeesRes.data || []
-        summaryData = summaryRes.data
-      } catch (error) {
-        console.log('Payroll API not available, using mock data')
-        
-        // Use mock data
-        runsData = [
-          {
-            id: '1',
-            payPeriod: '2025-01-01 to 2025-01-15',
-            scheduledDate: '2025-01-16',
-            status: 'pending',
-            totalAmount: 65000,
-            employeeCount: 12,
-            entries: []
-          },
-          {
-            id: '2',
-            payPeriod: '2024-12-16 to 2024-12-31',
-            scheduledDate: '2025-01-01',
-            status: 'processed',
-            totalAmount: 62000,
-            employeeCount: 12,
-            entries: []
-          }
-        ]
-        
-        employeesData = [
-          {
-            id: '1',
-            name: 'John Doe',
-            position: 'Software Engineer',
-            salary: 85000,
-            status: 'active',
-            startDate: '2024-01-15',
-            department: 'Engineering'
-          },
-          {
-            id: '2',
-            name: 'Jane Smith',
-            position: 'Product Manager',
-            salary: 95000,
-            status: 'active',
-            startDate: '2024-02-01',
-            department: 'Product'
-          }
-        ]
-        
-        summaryData = {
-          totalEmployees: 12,
-          activeEmployees: 12,
-          totalMonthlySalary: 65000,
-          nextPayrollDate: '2025-01-16'
-        }
-      }
-
-      setPayrollRuns(runsData)
-      setEmployees(employeesData)
-      setSummary(summaryData)
-    } catch (error) {
-      console.error('Error fetching payroll data:', error)
-    } finally {
-      setLoading(false)
-    }
+  const refreshData = async () => {
+    await Promise.all([mutRuns(), mutEmp(), mutSum()])
   }
 
   const approvePayroll = async (runId: string) => {
     try {
       await api.payroll.approveRun(runId, companyId)
-      setPayrollRuns(runs => runs.map(run => 
-        run.id === runId ? { ...run, status: 'approved' } : run
-      ))
+      await mutRuns()
     } catch (error) {
       console.error('Error approving payroll:', error)
     }
@@ -129,11 +63,19 @@ export default function PayrollDashboard() {
   const processPayroll = async (runId: string) => {
     try {
       await api.payroll.processRun(runId, companyId)
-      setPayrollRuns(runs => runs.map(run => 
-        run.id === runId ? { ...run, status: 'processed' } : run
-      ))
+      await mutRuns()
     } catch (error) {
       console.error('Error processing payroll:', error)
+    }
+  }
+
+  /** Trigger a new payroll run */
+  const runPayroll = async () => {
+    try {
+      await api.payroll.runPayroll({ companyId })
+      await Promise.all([mutRuns(), mutSum()])
+    } catch (err) {
+      console.error('Run payroll failed', err)
     }
   }
 
@@ -161,18 +103,78 @@ export default function PayrollDashboard() {
           <h1 className="text-2xl font-bold text-gray-900">Payroll</h1>
           <p className="text-gray-600">Manage payroll runs and employees</p>
         </div>
-        <Button 
-          onClick={fetchPayrollData}
-          className="flex items-center gap-2"
-        >
+        <div className="flex gap-2">
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+              <Button className="flex items-center gap-2">
+                <span className="text-xl">➕</span> Add Employee
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <div className="flex justify-between items-center mb-4">
+                <h2 className="text-lg font-semibold">Add Employee</h2>
+                <DialogClose asChild>
+                  <Button variant="ghost" size="sm">Close</Button>
+                </DialogClose>
+              </div>
+              <form
+                onSubmit={async e => {
+                  e.preventDefault()
+                  const formData = new FormData(e.currentTarget)
+                  await api.payroll.addEmployee({
+                    companyId,
+                    name: formData.get('name'),
+                    title: formData.get('title'),
+                    salary: Number(formData.get('salary') || 0),
+                    status: formData.get('status'),
+                  })
+                  await Promise.all([mutEmp(), mutSum()])
+                  setOpen(false)
+                  e.currentTarget.reset()
+                }}
+                className="space-y-4"
+              >
+                <input
+                  name="name"
+                  placeholder="Name"
+                  className="w-full border p-2 rounded"
+                  required
+                />
+                <input
+                  name="title"
+                  placeholder="Title"
+                  className="w-full border p-2 rounded"
+                  required
+                />
+                <input
+                  name="salary"
+                  type="number"
+                  step="0.01"
+                  placeholder="Salary"
+                  className="w-full border p-2 rounded"
+                  required
+                />
+                <select name="status" className="w-full border p-2 rounded">
+                  <option value="active">active</option>
+                  <option value="inactive">inactive</option>
+                </select>
+                <Button type="submit">Save</Button>
+              </form>
+          </DialogContent>
+        </Dialog>
+        <Button onClick={runPayroll} className="flex items-center gap-2">
+          <Play className="h-4 w-4" /> Run Payroll
+        </Button>
+        <Button onClick={refreshData} className="flex items-center gap-2">
           <RefreshCw className="h-4 w-4" />
           Refresh
         </Button>
       </div>
+      </div>
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-        <Card>
+        <Card className="dark:bg-gray-800">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Total Employees</CardTitle>
             <Users className="h-4 w-4 text-blue-600" />
@@ -181,20 +183,18 @@ export default function PayrollDashboard() {
             <div className="text-2xl font-bold text-blue-600">
               {summary?.totalEmployees || 0}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
-              {summary?.activeEmployees || 0} active
-            </p>
+            <p className="text-xs text-gray-600 mt-1">Total employees</p>
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="dark:bg-gray-800">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Monthly Payroll</CardTitle>
             <DollarSign className="h-4 w-4 text-green-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-green-600">
-              {formatCurrency(summary?.totalMonthlySalary || 0)}
+              {summary ? formatCurrency(summary.monthlyPayroll) : '$0'}
             </div>
             <p className="text-xs text-gray-600 mt-1">
               Total monthly cost
@@ -202,14 +202,14 @@ export default function PayrollDashboard() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="dark:bg-gray-800">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Next Payroll</CardTitle>
             <Calendar className="h-4 w-4 text-purple-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-purple-600">
-              {summary?.nextPayrollDate ? formatDate(summary.nextPayrollDate) : 'Not scheduled'}
+              {summary?.nextPayroll ? formatDate(summary.nextPayroll) : 'Not scheduled'}
             </div>
             <p className="text-xs text-gray-600 mt-1">
               Scheduled date
@@ -217,14 +217,14 @@ export default function PayrollDashboard() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="dark:bg-gray-800">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Pending Runs</CardTitle>
             <Clock className="h-4 w-4 text-yellow-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-yellow-600">
-              {payrollRuns.filter(run => run.status === 'pending' || run.status === 'draft').length}
+              {summary?.pendingRuns ?? 0}
             </div>
             <p className="text-xs text-gray-600 mt-1">
               Awaiting approval
@@ -234,7 +234,7 @@ export default function PayrollDashboard() {
       </div>
 
       {/* Payroll Runs */}
-      <Card>
+      <Card className="dark:bg-gray-800">
         <CardHeader>
           <CardTitle>Payroll Runs</CardTitle>
           <CardDescription>
@@ -243,12 +243,12 @@ export default function PayrollDashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            {payrollRuns.length === 0 ? (
+            {(payrollRuns?.data || []).length === 0 ? (
               <div className="text-center py-8 text-gray-500">
                 No payroll runs found
               </div>
             ) : (
-              payrollRuns.map((run) => (
+              (payrollRuns?.data || []).map((run: PayrollRun) => (
                 <div key={run.id} className="flex items-center justify-between p-4 border rounded">
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-1">
@@ -297,7 +297,7 @@ export default function PayrollDashboard() {
       </Card>
 
       {/* Employee List */}
-      <Card>
+      <Card className="dark:bg-gray-800">
         <CardHeader>
           <CardTitle>Employees</CardTitle>
           <CardDescription>
@@ -306,19 +306,21 @@ export default function PayrollDashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            {employees.length === 0 ? (
+            {(employees?.data || []).length === 0 ? (
               <div className="text-center py-8 text-gray-500">
                 No employees found
               </div>
             ) : (
-              employees.map((employee) => (
+              (employees?.data || []).map((employee: Employee) => (
                 <div key={employee.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
                   <div className="flex-1">
                     <div className="font-medium">{employee.name}</div>
-                    <div className="text-sm text-gray-600">{employee.position}</div>
-                    <div className="text-xs text-gray-500">
-                      {employee.department} • Started {formatDate(employee.startDate)}
-                    </div>
+                    <div className="text-sm text-gray-600">{employee.title}</div>
+                    {employee.start_date && (
+                      <div className="text-xs text-gray-500">
+                        {employee.department || 'General'} • Started {formatDate(employee.start_date)}
+                      </div>
+                    )}
                   </div>
                   <div className="text-right">
                     <div className="font-semibold">{formatCurrency(employee.salary)}</div>

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { cn } from '@frontend/lib/utils'
+
+/** Simple wrapper around Radix Dialog used throughout the demo */
+export const Dialog = DialogPrimitive.Root
+export const DialogTrigger = DialogPrimitive.Trigger
+export const DialogClose = DialogPrimitive.Close
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Overlay className="fixed inset-0 bg-black/40" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-md bg-white p-6 shadow',
+        'focus:outline-none',
+        className
+      )}
+      {...props}
+    />
+  </DialogPrimitive.Portal>
+))
+DialogContent.displayName = 'DialogContent'

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -79,6 +79,8 @@ export const api = {
     getRuns: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/runs?companyId=${companyId}`),
     getEmployees: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/employees?companyId=${companyId}`),
     getSummary: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/summary?companyId=${companyId}`),
+    addEmployee: (data: Record<string, unknown>) => apiClient.post('/api/payroll/employees', data),
+    runPayroll: (data: Record<string, unknown>) => apiClient.post('/api/payroll/run', data),
     getUpcoming: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/upcoming?companyId=${companyId}`),
     getStats: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/stats?companyId=${companyId}`),
     approveRun: (runId: string, companyId: string = 'demo-company') => apiClient.post(`/api/payroll/runs/${runId}/approve`, { companyId }),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -64,11 +64,11 @@ export interface PayrollEntry {
 export interface Employee {
   id: string
   name: string
-  position: string
+  title: string
   salary: number
   status: 'active' | 'inactive'
-  startDate: string
-  department: string
+  startDate?: string
+  department?: string
 }
 
 export interface BankAccount {

--- a/shared/db.ts
+++ b/shared/db.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js'
+
+/**
+ * Shared Supabase client instance used on both front-end and back-end.
+ * Uses public anon key which is safe for client-side usage.
+ */
+export const db = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '',
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || ''
+)

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -80,3 +80,19 @@ export interface AccessTokenResponse {
   itemId: string;
   requestId: string;
 }
+
+/**
+ * Employee record
+ */
+export interface Employee {
+  id: string;
+  company_id: string;
+  name: string;
+  title: string;
+  salary: number;
+  status: string;
+  department?: string | null;
+  start_date?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}


### PR DESCRIPTION
## Summary
- add shared Supabase db helper
- track schema changes
- create payroll summary and listing endpoints
- fetch payroll data in dashboard with SWR
- register payroll routes and add basic modal for adding employees
- add employee creation flow and fix dashboard
- log employee schema update
- fix payroll dashboard refresh flow
- run payroll from dashboard and persist runs
- initialize Check service for backend routes

## Testing
- `pnpm lint` *(fails: many no-unused-vars in backend)*
- `pnpm test --coverage` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687216ee0c008328912c9ba533fbb7b9