### PR TITLE
Fix duplicate .gitignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+!backend/logs/
+!backend/logs/SCHEMA_CHANGES.md
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/backend/logs/SCHEMA_CHANGES.md
+++ b/backend/logs/SCHEMA_CHANGES.md
@@ -1,0 +1,1 @@
+# Schema Changes


### PR DESCRIPTION
## Summary
- track backend log file once
- unignore `backend/logs` so the file is committed

## Testing
- `pnpm lint` *(fails: '_options' is defined but never used, etc.)*
- `pnpm test --coverage` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6873130f96388328bf9f781adaf8c86d