### PR TITLE
Clean merge markers in routes test

### DIFF
--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@backend': path.resolve(__dirname, 'src'),
+      '@backend/*': path.resolve(__dirname, 'src/*'),
+      '@shared': path.resolve(__dirname, '../shared'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',

--- a/tests/backend/routes.test.ts
+++ b/tests/backend/routes.test.ts
@@ -1,16 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FastifyInstance } from 'fastify';
-<<<<<<< HEAD:backend/src/test/routes.test.ts
 import { createServer } from '@backend/index';
 
 // Mock all the services
 vi.mock('@backend/services/cashflow', () => ({
-=======
-import { createServer } from '@backend/index.js';
-
-// Mock all the services
-vi.mock('@backend/services/cashflow.js', () => ({
->>>>>>> vp/clean-up-and-reorganize-codebase:tests/backend/routes.test.ts
   CashFlowService: vi.fn().mockImplementation(() => ({
     getCurrentAnalysis: vi.fn().mockResolvedValue({
       success: true,
@@ -38,11 +31,7 @@ vi.mock('@backend/services/cashflow.js', () => ({
   }))
 }));
 
-<<<<<<< HEAD:backend/src/test/routes.test.ts
 vi.mock('@backend/services/riskAssessment', () => ({
-=======
-vi.mock('@backend/services/riskAssessment.js', () => ({
->>>>>>> vp/clean-up-and-reorganize-codebase:tests/backend/routes.test.ts
   RiskAssessmentService: vi.fn().mockImplementation(() => ({
     getRiskStatus: vi.fn().mockResolvedValue({
       success: true,
@@ -71,11 +60,7 @@ vi.mock('@backend/services/riskAssessment.js', () => ({
   }))
 }));
 
-<<<<<<< HEAD:backend/src/test/routes.test.ts
 vi.mock('@backend/services/check', () => ({
-=======
-vi.mock('@backend/services/check.js', () => ({
->>>>>>> vp/clean-up-and-reorganize-codebase:tests/backend/routes.test.ts
   CheckService: vi.fn().mockImplementation(() => ({
     getPayrollRuns: vi.fn().mockResolvedValue({
       success: true,
@@ -108,11 +93,7 @@ vi.mock('@backend/services/check.js', () => ({
   }))
 }));
 
-<<<<<<< HEAD:backend/src/test/routes.test.ts
 vi.mock('@backend/services/plaid', () => ({
-=======
-vi.mock('@backend/services/plaid.js', () => ({
->>>>>>> vp/clean-up-and-reorganize-codebase:tests/backend/routes.test.ts
   PlaidService: vi.fn().mockImplementation(() => ({
     createLinkToken: vi.fn().mockResolvedValue({
       success: true,
@@ -135,11 +116,7 @@ vi.mock('@backend/services/plaid.js', () => ({
   }))
 }));
 
-<<<<<<< HEAD:backend/src/test/routes.test.ts
 vi.mock('@backend/services/slack', () => ({
-=======
-vi.mock('@backend/services/slack.js', () => ({
->>>>>>> vp/clean-up-and-reorganize-codebase:tests/backend/routes.test.ts
   SlackService: vi.fn().mockImplementation(() => ({
     sendNotification: vi.fn().mockResolvedValue({
       success: true,
@@ -165,11 +142,7 @@ vi.mock('@backend/services/slack.js', () => ({
   }))
 }));
 
-<<<<<<< HEAD:backend/src/test/routes.test.ts
 vi.mock('@backend/services/monitoring', () => ({
-=======
-vi.mock('@backend/services/monitoring.js', () => ({
->>>>>>> vp/clean-up-and-reorganize-codebase:tests/backend/routes.test.ts
   MonitoringService: vi.fn().mockImplementation(() => ({
     getSystemHealth: vi.fn().mockResolvedValue({
       success: true,

--- a/tests/backend/services/index.test.ts
+++ b/tests/backend/services/index.test.ts
@@ -11,11 +11,7 @@ import {
   PlaidService,
   CheckService,
   SlackService,
-<<<<<<< HEAD:backend/src/test/services/index.test.ts
 } from '@backend/services';
-=======
-} from '@backend/services/index';
->>>>>>> vp/clean-up-and-reorganize-codebase:tests/backend/services/index.test.ts
 
 // Mock environment variables
 const mockEnv = {


### PR DESCRIPTION
## Summary
- fix merge conflict markers in `tests/backend/routes.test.ts`
- fix merge conflict import in `tests/backend/services/index.test.ts`
- add alias resolution to Vitest config so tests can load modules

## Testing
- `SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=key npx vitest --config backend/vitest.config.ts tests/backend/routes.test.ts` *(fails: createServer is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68731324b52c8328971a68f2b271091d