### PR TITLE
Implement payroll run CRUD UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 SUPABASE_URL=your_supabase_url
 SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+SUPABASE_PAT=your_supabase_pat
+SUPABASE_REF=your_supabase_project_ref
 
 # External APIs
 PLAID_ENV=sandbox

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,6 +11,8 @@ FRONTEND_URL=http://localhost:3000
 SUPABASE_URL=your_supabase_url
 SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+SUPABASE_PAT=your_supabase_pat
+SUPABASE_REF=your_supabase_project_ref
 
 # Plaid Configuration
 PLAID_CLIENT_ID=replace-me

--- a/backend/migrations/001_initial.sql
+++ b/backend/migrations/001_initial.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS employees (
 CREATE TABLE IF NOT EXISTS payroll_runs (
   id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   company_id       UUID        REFERENCES companies(id) ON DELETE CASCADE,
+  check_payroll_id TEXT,
   run_number       TEXT UNIQUE NOT NULL,
   pay_period_start DATE        NOT NULL,
   pay_period_end   DATE        NOT NULL,
@@ -150,7 +151,8 @@ BEGIN
     CREATE POLICY allow_all_risk_assessments ON risk_assessments  FOR ALL USING (true);
     CREATE POLICY allow_all_alerts           ON alerts            FOR ALL USING (true);
   END IF;
-END$$;
+END;
+$$;
 
 /*──────────────  updated_at trigger  ──────────────*/
 

--- a/backend/migrations/001_initial.sql
+++ b/backend/migrations/001_initial.sql
@@ -1,0 +1,187 @@
+-- Enable UUID & pgcrypto extensions (idempotent)
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+/*──────────────────  CORE TABLES  ──────────────────*/
+
+-- Companies
+CREATE TABLE IF NOT EXISTS companies (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name               TEXT        NOT NULL,
+  ein                TEXT        NOT NULL,
+  state              TEXT        NOT NULL,
+  check_company_id   TEXT        NOT NULL,
+  created_at         TIMESTAMPTZ DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Employees  ★ restored
+CREATE TABLE IF NOT EXISTS employees (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id       UUID        REFERENCES companies(id) ON DELETE CASCADE,
+  employee_number  TEXT UNIQUE NOT NULL,
+  first_name       TEXT        NOT NULL,
+  last_name        TEXT        NOT NULL,
+  email            TEXT UNIQUE NOT NULL,
+  title            TEXT,
+  department       TEXT,
+  annual_salary    NUMERIC(10,2),
+  hourly_rate      NUMERIC(8,2),
+  is_active        BOOLEAN DEFAULT TRUE,
+  created_at       TIMESTAMPTZ DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Payroll runs (high-level pay periods)
+CREATE TABLE IF NOT EXISTS payroll_runs (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id       UUID        REFERENCES companies(id) ON DELETE CASCADE,
+  run_number       TEXT UNIQUE NOT NULL,
+  pay_period_start DATE        NOT NULL,
+  pay_period_end   DATE        NOT NULL,
+  pay_date         DATE        NOT NULL,
+  status           TEXT        NOT NULL DEFAULT 'draft' 
+                 CHECK (status IN ('draft','pending','approved','processed','cancelled')),
+  total_gross      NUMERIC(12,2) DEFAULT 0,
+  total_net        NUMERIC(12,2) DEFAULT 0,
+  total_taxes      NUMERIC(12,2) DEFAULT 0,
+  total_deductions NUMERIC(12,2) DEFAULT 0,
+  employee_count   INTEGER      DEFAULT 0,
+  created_at       TIMESTAMPTZ  DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ  DEFAULT NOW()
+);
+
+-- Payroll entries  ★ restored
+CREATE TABLE IF NOT EXISTS payroll_entries (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  payroll_run_id   UUID REFERENCES payroll_runs(id) ON DELETE CASCADE,
+  employee_id      UUID REFERENCES employees(id)    ON DELETE CASCADE,
+  gross_pay        NUMERIC(10,2) NOT NULL,
+  net_pay          NUMERIC(10,2) NOT NULL,
+  taxes            NUMERIC(10,2) DEFAULT 0,
+  deductions       NUMERIC(10,2) DEFAULT 0,
+  hours            NUMERIC(6,2),
+  status           TEXT DEFAULT 'pending'
+                 CHECK (status IN ('pending','approved','processed','cancelled')),
+  created_at       TIMESTAMPTZ DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Bank accounts
+CREATE TABLE IF NOT EXISTS bank_accounts (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id        UUID        REFERENCES companies(id) ON DELETE CASCADE,
+  plaid_account_id  TEXT UNIQUE NOT NULL,
+  plaid_access_token TEXT       NOT NULL,
+  account_name      TEXT        NOT NULL,
+  account_type      TEXT        NOT NULL,
+  account_subtype   TEXT,
+  institution_name  TEXT,
+  current_balance   NUMERIC(12,2),
+  available_balance NUMERIC(12,2),
+  is_active         BOOLEAN DEFAULT TRUE,
+  created_at        TIMESTAMPTZ DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Risk assessments
+CREATE TABLE IF NOT EXISTS risk_assessments (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id       UUID REFERENCES companies(id)      ON DELETE CASCADE,
+  bank_account_id  UUID REFERENCES bank_accounts(id)  ON DELETE CASCADE,
+  payroll_run_id   UUID REFERENCES payroll_runs(id)   ON DELETE CASCADE,
+  current_balance  NUMERIC(12,2) NOT NULL,
+  required_float   NUMERIC(12,2) NOT NULL,
+  risk_status      TEXT NOT NULL
+                 CHECK (risk_status IN ('safe','at_risk','critical')),
+  days_until_payroll INTEGER NOT NULL,
+  runway_days      INTEGER,
+  assessed_at      TIMESTAMPTZ DEFAULT NOW(),
+  created_at       TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Alerts
+CREATE TABLE IF NOT EXISTS alerts (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id        UUID REFERENCES companies(id)         ON DELETE CASCADE,
+  risk_assessment_id UUID REFERENCES risk_assessments(id) ON DELETE CASCADE,
+  alert_type        TEXT    NOT NULL DEFAULT 'payroll_risk',
+  status            TEXT    NOT NULL DEFAULT 'sent',
+  slack_message_ts  TEXT,
+  message_content   TEXT,
+  sent_at           TIMESTAMPTZ DEFAULT NOW(),
+  created_at        TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (risk_assessment_id, alert_type)
+);
+
+/*──────────────────────  INDEXES  ──────────────────────*/
+
+CREATE INDEX IF NOT EXISTS idx_employees_company_id          ON employees(company_id);
+CREATE INDEX IF NOT EXISTS idx_employees_active              ON employees(is_active);
+
+CREATE INDEX IF NOT EXISTS idx_payroll_runs_company_id       ON payroll_runs(company_id);
+CREATE INDEX IF NOT EXISTS idx_payroll_runs_status           ON payroll_runs(status);
+
+CREATE INDEX IF NOT EXISTS idx_payroll_entries_payroll_run_id ON payroll_entries(payroll_run_id);
+CREATE INDEX IF NOT EXISTS idx_payroll_entries_employee_id    ON payroll_entries(employee_id);
+
+CREATE INDEX IF NOT EXISTS idx_bank_accounts_company_id      ON bank_accounts(company_id);
+CREATE INDEX IF NOT EXISTS idx_risk_assessments_company_id   ON risk_assessments(company_id);
+
+/*──────────────  RLS  &  POLICIES  ──────────────*/
+
+ALTER TABLE companies         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE employees         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payroll_runs      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payroll_entries   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bank_accounts     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE risk_assessments  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE alerts            ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  -- quick “allow all” policies for dev
+  PERFORM 1 FROM pg_policies WHERE policyname = 'allow_all_companies';
+  IF NOT FOUND THEN
+    CREATE POLICY allow_all_companies          ON companies         FOR ALL USING (true);
+    CREATE POLICY allow_all_employees         ON employees         FOR ALL USING (true);
+    CREATE POLICY allow_all_pruns            ON payroll_runs      FOR ALL USING (true);
+    CREATE POLICY allow_all_pentries         ON payroll_entries   FOR ALL USING (true);
+    CREATE POLICY allow_all_bank_accounts    ON bank_accounts     FOR ALL USING (true);
+    CREATE POLICY allow_all_risk_assessments ON risk_assessments  FOR ALL USING (true);
+    CREATE POLICY allow_all_alerts           ON alerts            FOR ALL USING (true);
+  END IF;
+END$$;
+
+/*──────────────  updated_at trigger  ──────────────*/
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Companies
+DROP TRIGGER IF EXISTS trg_updated_companies ON companies;
+CREATE TRIGGER trg_updated_companies
+  BEFORE UPDATE ON companies
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Employees
+DROP TRIGGER IF EXISTS trg_updated_employees ON employees;
+CREATE TRIGGER trg_updated_employees
+  BEFORE UPDATE ON employees
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Payroll runs
+DROP TRIGGER IF EXISTS trg_updated_payroll_runs ON payroll_runs;
+CREATE TRIGGER trg_updated_payroll_runs
+  BEFORE UPDATE ON payroll_runs
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Payroll entries
+DROP TRIGGER IF EXISTS trg_updated_payroll_entries ON payroll_entries;
+CREATE TRIGGER trg_updated_payroll_entries
+  BEFORE UPDATE ON payroll_entries
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/backend/migrations/002_add_employee_title.sql
+++ b/backend/migrations/002_add_employee_title.sql
@@ -1,0 +1,2 @@
+-- Add title column to employees table if missing
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS title TEXT;

--- a/backend/migrations/003_update_payroll_entries.sql
+++ b/backend/migrations/003_update_payroll_entries.sql
@@ -1,0 +1,7 @@
+-- Ensure payroll_entries table has all required columns
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS net_pay NUMERIC(10,2);
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS taxes NUMERIC(10,2) DEFAULT 0;
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS deductions NUMERIC(10,2) DEFAULT 0;
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS hours NUMERIC(6,2);
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'pending' CHECK (status IN ('pending','approved','processed','cancelled'));
+

--- a/backend/migrations/003_update_payroll_entries.sql
+++ b/backend/migrations/003_update_payroll_entries.sql
@@ -4,4 +4,6 @@ ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS taxes NUMERIC(10,2) DEFAULT
 ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS deductions NUMERIC(10,2) DEFAULT 0;
 ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS hours NUMERIC(6,2);
 ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'pending' CHECK (status IN ('pending','approved','processed','cancelled'));
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
 

--- a/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
+++ b/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
@@ -42,6 +42,10 @@ ALTER TABLE payroll_runs ALTER COLUMN pay_date SET NOT NULL;
 ALTER TABLE payroll_runs ALTER COLUMN status SET DEFAULT 'draft';
 ALTER TABLE payroll_runs ALTER COLUMN status SET NOT NULL;
 
+-- Remove old unique constraint if present
+ALTER TABLE payroll_runs
+  DROP CONSTRAINT IF EXISTS payroll_runs_run_number_key;
+
 -- Ensure status check constraint
 DO $$
 BEGIN
@@ -57,16 +61,17 @@ BEGIN
 END;
 $$;
 
--- Ensure run_number uniqueness
+-- Ensure run_number and company_id uniqueness
 DO $$
 BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_constraint
-    WHERE conname = 'payroll_runs_run_number_key'
+    WHERE conname = 'payroll_runs_run_number_company_id_key'
       AND conrelid = 'payroll_runs'::regclass
   ) THEN
     ALTER TABLE payroll_runs
-      ADD CONSTRAINT payroll_runs_run_number_key UNIQUE (run_number);
+      ADD CONSTRAINT payroll_runs_run_number_company_id_key
+        UNIQUE (run_number, company_id);
   END IF;
 END;
 $$;

--- a/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
+++ b/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
@@ -1,0 +1,46 @@
+-- Align payroll_runs table with canonical schema
+DO $$
+BEGIN
+  -- Add missing columns if they don't exist
+  ALTER TABLE payroll_runs
+    ADD COLUMN IF NOT EXISTS run_number TEXT,
+    ADD COLUMN IF NOT EXISTS pay_period_start DATE,
+    ADD COLUMN IF NOT EXISTS pay_period_end DATE,
+    ADD COLUMN IF NOT EXISTS total_gross NUMERIC(12,2) DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS total_net NUMERIC(12,2) DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS total_taxes NUMERIC(12,2) DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS total_deductions NUMERIC(12,2) DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS employee_count INTEGER DEFAULT 0;
+
+  -- Rename total_amount -> total_gross if needed
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='payroll_runs' AND column_name='total_amount'
+  ) THEN
+    UPDATE payroll_runs SET total_gross = COALESCE(total_amount,0)
+      WHERE total_gross = 0;
+    ALTER TABLE payroll_runs DROP COLUMN total_amount;
+  END IF;
+
+  -- Set constraints and defaults
+  ALTER TABLE payroll_runs
+    ALTER COLUMN run_number SET NOT NULL,
+    ALTER COLUMN pay_period_start SET NOT NULL,
+    ALTER COLUMN pay_period_end SET NOT NULL,
+    ALTER COLUMN pay_date SET NOT NULL,
+    ALTER COLUMN status SET DEFAULT 'draft',
+    ALTER COLUMN status SET NOT NULL;
+
+  -- Ensure status check constraint
+  ALTER TABLE payroll_runs
+    ADD CONSTRAINT IF NOT EXISTS payroll_runs_status_check
+      CHECK (status IN ('draft','pending','approved','processed','cancelled'));
+
+  -- Ensure run_number uniqueness
+  ALTER TABLE payroll_runs
+    ADD CONSTRAINT IF NOT EXISTS payroll_runs_run_number_key UNIQUE (run_number);
+
+END $$;
+
+-- Log for migration runner
+SELECT '[migration] payroll_runs columns ensured' AS info;

--- a/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
+++ b/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
@@ -40,13 +40,31 @@ ALTER TABLE payroll_runs ALTER COLUMN status SET DEFAULT 'draft';
 ALTER TABLE payroll_runs ALTER COLUMN status SET NOT NULL;
 
 -- Ensure status check constraint
-ALTER TABLE payroll_runs
-  ADD CONSTRAINT IF NOT EXISTS payroll_runs_status_check
-    CHECK (status IN ('draft','pending','approved','processed','cancelled'));
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'payroll_runs_status_check'
+      AND conrelid = 'payroll_runs'::regclass
+  ) THEN
+    ALTER TABLE payroll_runs
+      ADD CONSTRAINT payroll_runs_status_check
+        CHECK (status IN ('draft','pending','approved','processed','cancelled'));
+  END IF;
+END$$;
 
 -- Ensure run_number uniqueness
-ALTER TABLE payroll_runs
-  ADD CONSTRAINT IF NOT EXISTS payroll_runs_run_number_key UNIQUE (run_number);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'payroll_runs_run_number_key'
+      AND conrelid = 'payroll_runs'::regclass
+  ) THEN
+    ALTER TABLE payroll_runs
+      ADD CONSTRAINT payroll_runs_run_number_key UNIQUE (run_number);
+  END IF;
+END$$;
 
 -- Log for migration runner
 SELECT '[migration] payroll_runs columns ensured' AS info;

--- a/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
+++ b/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
@@ -1,46 +1,52 @@
 -- Align payroll_runs table with canonical schema
+-- Add missing columns
+ALTER TABLE payroll_runs
+  ADD COLUMN IF NOT EXISTS run_number TEXT;
+ALTER TABLE payroll_runs
+  ADD COLUMN IF NOT EXISTS pay_period_start DATE;
+ALTER TABLE payroll_runs
+  ADD COLUMN IF NOT EXISTS pay_period_end DATE;
+ALTER TABLE payroll_runs
+  ADD COLUMN IF NOT EXISTS total_gross NUMERIC(12,2) DEFAULT 0;
+ALTER TABLE payroll_runs
+  ADD COLUMN IF NOT EXISTS total_net NUMERIC(12,2) DEFAULT 0;
+ALTER TABLE payroll_runs
+  ADD COLUMN IF NOT EXISTS total_taxes NUMERIC(12,2) DEFAULT 0;
+ALTER TABLE payroll_runs
+  ADD COLUMN IF NOT EXISTS total_deductions NUMERIC(12,2) DEFAULT 0;
+ALTER TABLE payroll_runs
+  ADD COLUMN IF NOT EXISTS employee_count INTEGER DEFAULT 0;
+
+-- Rename total_amount -> total_gross if needed
 DO $$
 BEGIN
-  -- Add missing columns if they don't exist
-  ALTER TABLE payroll_runs
-    ADD COLUMN IF NOT EXISTS run_number TEXT,
-    ADD COLUMN IF NOT EXISTS pay_period_start DATE,
-    ADD COLUMN IF NOT EXISTS pay_period_end DATE,
-    ADD COLUMN IF NOT EXISTS total_gross NUMERIC(12,2) DEFAULT 0,
-    ADD COLUMN IF NOT EXISTS total_net NUMERIC(12,2) DEFAULT 0,
-    ADD COLUMN IF NOT EXISTS total_taxes NUMERIC(12,2) DEFAULT 0,
-    ADD COLUMN IF NOT EXISTS total_deductions NUMERIC(12,2) DEFAULT 0,
-    ADD COLUMN IF NOT EXISTS employee_count INTEGER DEFAULT 0;
-
-  -- Rename total_amount -> total_gross if needed
   IF EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name='payroll_runs' AND column_name='total_amount'
+    WHERE table_name = 'payroll_runs' AND column_name = 'total_amount'
   ) THEN
-    UPDATE payroll_runs SET total_gross = COALESCE(total_amount,0)
+    UPDATE payroll_runs
+      SET total_gross = COALESCE(total_amount, 0)
       WHERE total_gross = 0;
     ALTER TABLE payroll_runs DROP COLUMN total_amount;
   END IF;
+END$$;
 
-  -- Set constraints and defaults
-  ALTER TABLE payroll_runs
-    ALTER COLUMN run_number SET NOT NULL,
-    ALTER COLUMN pay_period_start SET NOT NULL,
-    ALTER COLUMN pay_period_end SET NOT NULL,
-    ALTER COLUMN pay_date SET NOT NULL,
-    ALTER COLUMN status SET DEFAULT 'draft',
-    ALTER COLUMN status SET NOT NULL;
+-- Set constraints and defaults
+ALTER TABLE payroll_runs ALTER COLUMN run_number SET NOT NULL;
+ALTER TABLE payroll_runs ALTER COLUMN pay_period_start SET NOT NULL;
+ALTER TABLE payroll_runs ALTER COLUMN pay_period_end SET NOT NULL;
+ALTER TABLE payroll_runs ALTER COLUMN pay_date SET NOT NULL;
+ALTER TABLE payroll_runs ALTER COLUMN status SET DEFAULT 'draft';
+ALTER TABLE payroll_runs ALTER COLUMN status SET NOT NULL;
 
-  -- Ensure status check constraint
-  ALTER TABLE payroll_runs
-    ADD CONSTRAINT IF NOT EXISTS payroll_runs_status_check
-      CHECK (status IN ('draft','pending','approved','processed','cancelled'));
+-- Ensure status check constraint
+ALTER TABLE payroll_runs
+  ADD CONSTRAINT IF NOT EXISTS payroll_runs_status_check
+    CHECK (status IN ('draft','pending','approved','processed','cancelled'));
 
-  -- Ensure run_number uniqueness
-  ALTER TABLE payroll_runs
-    ADD CONSTRAINT IF NOT EXISTS payroll_runs_run_number_key UNIQUE (run_number);
-
-END $$;
+-- Ensure run_number uniqueness
+ALTER TABLE payroll_runs
+  ADD CONSTRAINT IF NOT EXISTS payroll_runs_run_number_key UNIQUE (run_number);
 
 -- Log for migration runner
 SELECT '[migration] payroll_runs columns ensured' AS info;

--- a/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
+++ b/backend/migrations/20230719_add_full_columns_to_payroll_runs.sql
@@ -7,6 +7,8 @@ ALTER TABLE payroll_runs
 ALTER TABLE payroll_runs
   ADD COLUMN IF NOT EXISTS pay_period_end DATE;
 ALTER TABLE payroll_runs
+  ADD COLUMN IF NOT EXISTS check_payroll_id TEXT;
+ALTER TABLE payroll_runs
   ADD COLUMN IF NOT EXISTS total_gross NUMERIC(12,2) DEFAULT 0;
 ALTER TABLE payroll_runs
   ADD COLUMN IF NOT EXISTS total_net NUMERIC(12,2) DEFAULT 0;
@@ -29,7 +31,8 @@ BEGIN
       WHERE total_gross = 0;
     ALTER TABLE payroll_runs DROP COLUMN total_amount;
   END IF;
-END$$;
+END;
+$$;
 
 -- Set constraints and defaults
 ALTER TABLE payroll_runs ALTER COLUMN run_number SET NOT NULL;
@@ -51,7 +54,8 @@ BEGIN
       ADD CONSTRAINT payroll_runs_status_check
         CHECK (status IN ('draft','pending','approved','processed','cancelled'));
   END IF;
-END$$;
+END;
+$$;
 
 -- Ensure run_number uniqueness
 DO $$
@@ -64,7 +68,8 @@ BEGIN
     ALTER TABLE payroll_runs
       ADD CONSTRAINT payroll_runs_run_number_key UNIQUE (run_number);
   END IF;
-END$$;
+END;
+$$;
 
 -- Log for migration runner
 SELECT '[migration] payroll_runs columns ensured' AS info;

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -2,57 +2,27 @@ import fs from 'fs';
 import path from 'path';
 import { supabase } from './client';
 
-/**
- * Ensure employee table exists with latest columns.
- * This helper can run at startup or via CLI to apply missing schema
- * changes. It logs each change to logs/SCHEMA_CHANGES.md.
- */
-export async function ensurePayrollSchema(): Promise<void> {
-  // Check employees table
-  const { error: tableError } = await supabase
-    .from('employees')
-    .select('id')
-    .limit(1);
+/** Path to the migrations directory */
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../migrations');
 
+/**
+ * Apply all SQL files in the migrations folder. The SQL files should be
+ * idempotent (use `IF NOT EXISTS`) so running them multiple times is safe.
+ */
+export async function applyMigrations(): Promise<void> {
   const logPath = path.resolve(__dirname, '../..', 'logs', 'SCHEMA_CHANGES.md');
 
-  if (tableError?.code === '42P01') {
-    const sql = `
-      CREATE TABLE employees (
-        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-        company_id uuid REFERENCES companies(id) ON DELETE CASCADE,
-        employee_number text UNIQUE NOT NULL,
-        first_name text NOT NULL,
-        last_name text NOT NULL,
-        email text UNIQUE NOT NULL,
-        title text,
-        department text,
-        annual_salary numeric(10,2),
-        hourly_rate numeric(8,2),
-        is_active boolean DEFAULT true,
-        created_at timestamp with time zone DEFAULT now(),
-        updated_at timestamp with time zone DEFAULT now()
-      );`;
-    const { error: createError } = await supabase.rpc('execute_sql', { sql });
-    if (createError) {
-      throw new Error(`Failed to create employees table: ${createError.message}`);
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter(f => f.endsWith('.sql'))
+    .sort();
+
+  for (const file of files) {
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8');
+    const { error } = await supabase.rpc('execute_sql', { sql });
+    if (error) {
+      throw new Error(`Failed to apply migration ${file}: ${error.message}`);
     }
-    fs.appendFileSync(logPath, `- ${new Date().toISOString()}: created employees table\n`);
-  }
-
-  // Ensure department column
-  const { error: deptError } = await supabase.from('employees').select('department').limit(1);
-  if (deptError?.code === '42703') {
-    const { error } = await supabase.rpc('execute_sql', { sql: 'ALTER TABLE employees ADD COLUMN department text;' });
-    if (error) throw new Error(`Failed to add department column: ${error.message}`);
-    fs.appendFileSync(logPath, `- ${new Date().toISOString()}: added employees.department column\n`);
-  }
-
-  // Ensure title column
-  const { error: titleError } = await supabase.from('employees').select('title').limit(1);
-  if (titleError?.code === '42703') {
-    const { error } = await supabase.rpc('execute_sql', { sql: 'ALTER TABLE employees ADD COLUMN title text;' });
-    if (error) throw new Error(`Failed to add title column: ${error.message}`);
-    fs.appendFileSync(logPath, `- ${new Date().toISOString()}: added employees.title column\n`);
+    fs.appendFileSync(logPath, `- ${new Date().toISOString()}: applied ${file}\n`);
   }
 }

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -2,28 +2,16 @@ import fs from 'fs';
 import path from 'path';
 import { supabase } from './client';
 
-/** Name of the table tracking applied migrations */
-const MIGRATION_TABLE = 'schema_migrations';
-
 /** Path to the migrations directory */
 const MIGRATIONS_DIR = path.resolve(__dirname, '../../migrations');
 
 /**
- * Apply pending SQL migrations in sequence. Each file is run only once and
- * recorded in the `schema_migrations` table. SQL files themselves should be
- * idempotent to safely re-run if needed.
+ * Apply all SQL migrations located in the migrations directory.  Each file
+ * should be idempotent so running this function repeatedly keeps the schema
+ * in sync without additional tracking tables.
  */
 export async function applyMigrations(): Promise<void> {
   const logPath = path.resolve(__dirname, '../..', 'logs', 'SCHEMA_CHANGES.md');
-
-  // ensure the migrations tracking table exists
-  await supabase.rpc('execute_sql', {
-    sql: `CREATE TABLE IF NOT EXISTS ${MIGRATION_TABLE} (
-      id SERIAL PRIMARY KEY,
-      filename TEXT UNIQUE NOT NULL,
-      applied_at TIMESTAMPTZ DEFAULT NOW()
-    );`,
-  });
 
   const files = fs
     .readdirSync(MIGRATIONS_DIR)
@@ -31,26 +19,12 @@ export async function applyMigrations(): Promise<void> {
     .sort();
 
   for (const file of files) {
-    const { data: row, error: selectErr } = await supabase
-      .from(MIGRATION_TABLE)
-      .select('id')
-      .eq('filename', file)
-      .maybeSingle();
-
-    if (selectErr) {
-      throw new Error(`Failed to read migration table: ${selectErr.message}`);
-    }
-
-    // skip already applied migrations
-    if (row) continue;
-
     const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8');
     const { error } = await supabase.rpc('execute_sql', { sql });
     if (error) {
       throw new Error(`Failed to apply migration ${file}: ${error.message}`);
     }
 
-    await supabase.from(MIGRATION_TABLE).insert({ filename: file });
     fs.appendFileSync(
       logPath,
       `- ${new Date().toISOString()}: applied ${file}\n`

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -25,6 +25,10 @@ export async function applyMigrations(): Promise<void> {
       throw new Error(`Failed to apply migration ${file}: ${error.message}`);
     }
 
+    if (file === '20230719_add_full_columns_to_payroll_runs.sql') {
+      console.info('[migration] payroll_runs columns ensured');
+    }
+
     fs.appendFileSync(
       logPath,
       `- ${new Date().toISOString()}: applied ${file}\n`

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -2,15 +2,28 @@ import fs from 'fs';
 import path from 'path';
 import { supabase } from './client';
 
+/** Name of the table tracking applied migrations */
+const MIGRATION_TABLE = 'schema_migrations';
+
 /** Path to the migrations directory */
 const MIGRATIONS_DIR = path.resolve(__dirname, '../../migrations');
 
 /**
- * Apply all SQL files in the migrations folder. The SQL files should be
- * idempotent (use `IF NOT EXISTS`) so running them multiple times is safe.
+ * Apply pending SQL migrations in sequence. Each file is run only once and
+ * recorded in the `schema_migrations` table. SQL files themselves should be
+ * idempotent to safely re-run if needed.
  */
 export async function applyMigrations(): Promise<void> {
   const logPath = path.resolve(__dirname, '../..', 'logs', 'SCHEMA_CHANGES.md');
+
+  // ensure the migrations tracking table exists
+  await supabase.rpc('execute_sql', {
+    sql: `CREATE TABLE IF NOT EXISTS ${MIGRATION_TABLE} (
+      id SERIAL PRIMARY KEY,
+      filename TEXT UNIQUE NOT NULL,
+      applied_at TIMESTAMPTZ DEFAULT NOW()
+    );`,
+  });
 
   const files = fs
     .readdirSync(MIGRATIONS_DIR)
@@ -18,11 +31,29 @@ export async function applyMigrations(): Promise<void> {
     .sort();
 
   for (const file of files) {
+    const { data: row, error: selectErr } = await supabase
+      .from(MIGRATION_TABLE)
+      .select('id')
+      .eq('filename', file)
+      .maybeSingle();
+
+    if (selectErr) {
+      throw new Error(`Failed to read migration table: ${selectErr.message}`);
+    }
+
+    // skip already applied migrations
+    if (row) continue;
+
     const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8');
     const { error } = await supabase.rpc('execute_sql', { sql });
     if (error) {
       throw new Error(`Failed to apply migration ${file}: ${error.message}`);
     }
-    fs.appendFileSync(logPath, `- ${new Date().toISOString()}: applied ${file}\n`);
+
+    await supabase.from(MIGRATION_TABLE).insert({ filename: file });
+    fs.appendFileSync(
+      logPath,
+      `- ${new Date().toISOString()}: applied ${file}\n`
+    );
   }
 }

--- a/backend/src/routes/payroll.ts
+++ b/backend/src/routes/payroll.ts
@@ -103,8 +103,15 @@ export default async function payrollRoutes(fastify: FastifyInstance) {
       await supabase.from('payroll_runs').insert({
         company_id: companyId,
         check_payroll_id: payrollRunId,
+        run_number: `run_${Date.now()}`,
+        pay_period_start: new Date().toISOString().split('T')[0],
+        pay_period_end: new Date().toISOString().split('T')[0],
         pay_date: new Date().toISOString().split('T')[0],
-        total_amount: 0,
+        total_gross: 0,
+        total_net: 0,
+        total_taxes: 0,
+        total_deductions: 0,
+        employee_count: 0,
         status,
       });
 

--- a/backend/src/scripts/apply-migrations.ts
+++ b/backend/src/scripts/apply-migrations.ts
@@ -5,11 +5,11 @@
  * Usage: npm run migrate
  */
 import '@backend/loadEnv';
-import { ensurePayrollSchema } from '../db/migrations';
+import { applyMigrations } from '../db/migrations';
 
 async function run(): Promise<void> {
   try {
-    await ensurePayrollSchema();
+    await applyMigrations();
     console.log('✅ Schema migrations applied');
   } catch (err) {
     console.error('❌ Failed to apply migrations', err);

--- a/backend/src/scripts/apply-migrations.ts
+++ b/backend/src/scripts/apply-migrations.ts
@@ -7,6 +7,14 @@
 import '@backend/loadEnv';
 import { applyMigrations } from '../db/migrations';
 
+// Make PAT and project ref available to the Supabase CLI if present
+if (process.env.SUPABASE_PAT && !process.env.SUPABASE_ACCESS_TOKEN) {
+  process.env.SUPABASE_ACCESS_TOKEN = process.env.SUPABASE_PAT;
+}
+if (process.env.SUPABASE_REF && !process.env.SUPABASE_PROJECT_REF) {
+  process.env.SUPABASE_PROJECT_REF = process.env.SUPABASE_REF;
+}
+
 async function run(): Promise<void> {
   try {
     await applyMigrations();

--- a/frontend/src/components/payroll/RunDrawer.tsx
+++ b/frontend/src/components/payroll/RunDrawer.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogContent, DialogClose } from '@frontend/components/ui/dial
 import { Button } from '@frontend/components/ui/button'
 import { api } from '@frontend/lib/api'
 import { formatCurrency, formatDate } from '@frontend/lib/utils'
+import { Loader } from 'lucide-react'
 import { useCompany } from '@frontend/context/CompanyContext'
 import type { PayrollRun } from '@frontend/types'
 import RunModal from './RunModal'
@@ -86,17 +87,27 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
             <div className="flex gap-2 mt-4 flex-wrap">
               {['draft', 'pending'].includes(run.status) && (
                 <>
-                  <Button size="sm" onClick={() => setEditing(true)}>Edit</Button>
-                  <Button size="sm" variant="destructive" onClick={remove}>Delete</Button>
+                  <Button size="sm" onClick={() => setEditing(true)} disabled={loading}>
+                    {loading ? <Loader className="h-4 w-4 animate-spin" /> : 'Edit'}
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={remove} disabled={loading}>
+                    {loading ? <Loader className="h-4 w-4 animate-spin" /> : 'Delete'}
+                  </Button>
                 </>
               )}
               {run.status === 'pending' && (
-                <Button size="sm" onClick={approve}>Approve</Button>
+                <Button size="sm" onClick={approve} disabled={loading}>
+                  {loading ? <Loader className="h-4 w-4 animate-spin" /> : 'Approve'}
+                </Button>
               )}
               {run.status === 'approved' && (
                 <>
-                  <Button size="sm" onClick={process}>Process</Button>
-                  <Button size="sm" variant="outline" onClick={revert}>Revert</Button>
+                  <Button size="sm" onClick={process} disabled={loading}>
+                    {loading ? <Loader className="h-4 w-4 animate-spin" /> : 'Process'}
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={revert} disabled={loading}>
+                    {loading ? <Loader className="h-4 w-4 animate-spin" /> : 'Revert'}
+                  </Button>
                 </>
               )}
               {run.status === 'processed' && (
@@ -104,15 +115,14 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
               )}
             </div>
           </div>
-        )}
-      </DialogContent>
-    </Dialog>
-    <RunModal
-      open={editing}
-      onOpenChange={setEditing}
-      onSaved={onUpdated}
-      run={run}
-    />
+        </DialogContent>
+      </Dialog>
+      <RunModal
+        open={editing}
+        onOpenChange={setEditing}
+        onSaved={onUpdated}
+        run={run}
+      />
     </>
   )
 }

--- a/frontend/src/components/payroll/RunDrawer.tsx
+++ b/frontend/src/components/payroll/RunDrawer.tsx
@@ -68,7 +68,10 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
   return (
     <>
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="fixed right-0 top-0 h-full w-full max-w-md rounded-none bg-white p-6 text-black">
+      {/* Drawer-style content positioned on the right without the default modal transforms */}
+      <DialogContent
+        className="fixed right-0 top-0 left-auto translate-x-0 translate-y-0 h-full w-full max-w-md rounded-none bg-white p-6 text-black"
+      >
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-semibold">Payroll Run</h2>
           <DialogClose asChild>
@@ -96,7 +99,15 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
             <div className="flex gap-2 mt-4 flex-wrap">
               {['draft', 'pending'].includes(run.status) && (
                 <>
-                  <Button size="sm" onClick={() => setEditing(true)} disabled={loading}>
+                  <Button
+                    size="sm"
+                    onClick={() => {
+                      // Close drawer so the edit modal is unobstructed
+                      setEditing(true)
+                      onOpenChange(false)
+                    }}
+                    disabled={loading}
+                  >
                     {loading ? <Loader className="h-4 w-4 animate-spin" /> : 'Edit'}
                   </Button>
                   <Button size="sm" variant="destructive" onClick={remove} disabled={loading}>

--- a/frontend/src/components/payroll/RunDrawer.tsx
+++ b/frontend/src/components/payroll/RunDrawer.tsx
@@ -77,11 +77,20 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
         </div>
 
         <div className="space-y-2">
-            <div className="font-medium">
-              Period: {run.pay_period_start} to {run.pay_period_end}
-            </div>
-            <div className="text-sm">Pay Date: {formatDate(run.pay_date)}</div>
-            <div className="text-sm">Amount: {formatCurrency(run.total_gross)}</div>
+            {(() => {
+              const r: any = run
+              const start = r.pay_period_start ?? r.payPeriodStart
+              const end = r.pay_period_end ?? r.payPeriodEnd
+              const payDate = r.pay_date ?? r.payDate
+              const gross = r.total_gross ?? r.totalAmount
+              return (
+                <>
+                  <div className="font-medium">Period: {start} to {end}</div>
+                  <div className="text-sm">Pay Date: {formatDate(payDate)}</div>
+                  <div className="text-sm">Amount: {formatCurrency(gross)}</div>
+                </>
+              )
+            })()}
             <div className="text-sm">Employees: {run.employee_count}</div>
             <div className="text-sm">Status: {run.status}</div>
             <div className="flex gap-2 mt-4 flex-wrap">

--- a/frontend/src/components/payroll/RunModal.tsx
+++ b/frontend/src/components/payroll/RunModal.tsx
@@ -37,10 +37,12 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
 
   useEffect(() => {
     if (!open) return
-    setStart(run?.pay_period_start || '')
-    setEnd(run?.pay_period_end || '')
-    setPayDate(run?.pay_date || '')
-    setGross(run ? String(run.total_gross) : '')
+    // Support both new and legacy field names so edits work pre-migration
+    const r: any = run || {}
+    setStart(r.pay_period_start ?? r.payPeriodStart ?? '')
+    setEnd(r.pay_period_end ?? r.payPeriodEnd ?? '')
+    setPayDate(r.pay_date ?? r.payDate ?? '')
+    setGross(run ? String(r.total_gross ?? r.totalAmount ?? 0) : '')
     if (employees && !isEdit) {
       setSelected(employees.data.map((e: Employee) => e.id))
     }

--- a/frontend/src/components/payroll/RunModal.tsx
+++ b/frontend/src/components/payroll/RunModal.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import useSWR from 'swr'
+import { Dialog, DialogContent, DialogClose } from '@frontend/components/ui/dialog'
+import { Button } from '@frontend/components/ui/button'
+import { api, apiClient } from '@frontend/lib/api'
+import { useCompany } from '@frontend/context/CompanyContext'
+import type { PayrollRun, Employee } from '@frontend/types'
+import { Loader } from 'lucide-react'
+
+interface RunModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSaved: () => void
+  run?: PayrollRun
+}
+
+const fetcher = (url: string) => apiClient.get(url).then(res => res.data)
+
+/** Modal for creating or editing a payroll run */
+export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalProps) {
+  const { companyId } = useCompany()
+  const isEdit = !!run
+
+  const { data: employees } = useSWR(
+    open && companyId ? `/api/payroll/employees?companyId=${companyId}` : null,
+    fetcher
+  )
+
+  const [start, setStart] = useState('')
+  const [end, setEnd] = useState('')
+  const [payDate, setPayDate] = useState('')
+  const [selected, setSelected] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setStart(run?.pay_period_start || '')
+    setEnd(run?.pay_period_end || '')
+    setPayDate(run?.pay_date || '')
+    if (employees && !isEdit) {
+      setSelected(employees.data.map((e: Employee) => e.id))
+    }
+  }, [open, run, employees, isEdit])
+
+  const toggle = (id: string) => {
+    setSelected(prev =>
+      prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
+    )
+  }
+  const selectAll = () => {
+    if (employees) setSelected(employees.data.map((e: Employee) => e.id))
+  }
+  const deselectAll = () => setSelected([])
+
+  const submit = async (draft: boolean) => {
+    if (!companyId) return
+    setLoading(true)
+    try {
+      if (isEdit && run) {
+        await api.payroll.updateRun(
+          run.id,
+          { payPeriodStart: start, payPeriodEnd: end, payDate },
+          companyId
+        )
+      } else {
+        await api.payroll.createRun({
+          companyId,
+          payPeriodStart: start,
+          payPeriodEnd: end,
+          payDate,
+          employeeIds: selected,
+          draft,
+        })
+      }
+      onSaved()
+      onOpenChange(false)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="text-black">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">
+            {isEdit ? 'Edit Payroll Run' : 'New Payroll Run'}
+          </h2>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm">Close</Button>
+          </DialogClose>
+        </div>
+        <form
+          onSubmit={e => {
+            e.preventDefault()
+            submit(true)
+          }}
+          className="space-y-4"
+        >
+          <div>
+            <label htmlFor="start" className="block text-sm font-medium mb-1">
+              Period Start
+            </label>
+            <input
+              id="start"
+              type="date"
+              value={start}
+              onChange={e => setStart(e.target.value)}
+              className="w-full border p-2 rounded"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="end" className="block text-sm font-medium mb-1">
+              Period End
+            </label>
+            <input
+              id="end"
+              type="date"
+              value={end}
+              onChange={e => setEnd(e.target.value)}
+              className="w-full border p-2 rounded"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="payDate" className="block text-sm font-medium mb-1">
+              Pay Date
+            </label>
+            <input
+              id="payDate"
+              type="date"
+              value={payDate}
+              onChange={e => setPayDate(e.target.value)}
+              className="w-full border p-2 rounded"
+              required
+            />
+          </div>
+          {employees && (
+            <div className="border p-2 rounded max-h-40 overflow-auto space-y-1">
+              <div className="flex justify-between mb-2 text-sm">
+                <button type="button" onClick={selectAll}>Select all</button>
+                <button type="button" onClick={deselectAll}>Deselect all</button>
+              </div>
+              {employees.data.map((emp: Employee) => (
+                <label key={emp.id} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(emp.id)}
+                    onChange={() => toggle(emp.id)}
+                  />
+                  {emp.name}
+                </label>
+              ))}
+            </div>
+          )}
+          <div className="flex gap-2">
+            {isEdit ? (
+              <Button type="submit" disabled={loading}>
+                {loading ? <Loader className="animate-spin" /> : 'Save'}
+              </Button>
+            ) : (
+              <>
+                <Button
+                  type="button"
+                  disabled={loading}
+                  onClick={() => submit(true)}
+                >
+                  {loading ? <Loader className="animate-spin" /> : 'Save Draft'}
+                </Button>
+                <Button
+                  type="button"
+                  disabled={loading}
+                  onClick={() => submit(false)}
+                >
+                  {loading ? <Loader className="animate-spin" /> : 'Submit'}
+                </Button>
+              </>
+            )}
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/payroll/RunModal.tsx
+++ b/frontend/src/components/payroll/RunModal.tsx
@@ -32,6 +32,7 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
   const [end, setEnd] = useState('')
   const [payDate, setPayDate] = useState('')
   const [selected, setSelected] = useState<string[]>([])
+  const [gross, setGross] = useState('')
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
@@ -39,6 +40,7 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
     setStart(run?.pay_period_start || '')
     setEnd(run?.pay_period_end || '')
     setPayDate(run?.pay_date || '')
+    setGross(run ? String(run.total_gross) : '')
     if (employees && !isEdit) {
       setSelected(employees.data.map((e: Employee) => e.id))
     }
@@ -61,7 +63,7 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
       if (isEdit && run) {
         await api.payroll.updateRun(
           run.id,
-          { payPeriodStart: start, payPeriodEnd: end, payDate },
+          { payPeriodStart: start, payPeriodEnd: end, payDate, totalGross: Number(gross) || 0 },
           companyId
         )
       } else {
@@ -71,6 +73,7 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
           payPeriodEnd: end,
           payDate,
           employeeIds: selected,
+          totalGross: Number(gross) || 0,
           draft,
         })
       }
@@ -134,6 +137,20 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
               type="date"
               value={payDate}
               onChange={e => setPayDate(e.target.value)}
+              className="w-full border p-2 rounded"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="gross" className="block text-sm font-medium mb-1">
+              Gross Amount
+            </label>
+            <input
+              id="gross"
+              type="number"
+              step="0.01"
+              value={gross}
+              onChange={e => setGross(e.target.value)}
               className="w-full border p-2 rounded"
               required
             />

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -328,14 +328,19 @@ import RunModal from '@frontend/components/payroll/RunModal'
                         {run.status}
                       </div>
                       <div className="font-medium">
-                        {run.pay_period_start} to {run.pay_period_end}
+                        {(() => {
+                          const r: any = run
+                          const start = r.pay_period_start ?? r.payPeriodStart
+                          const end = r.pay_period_end ?? r.payPeriodEnd
+                          return `${start} to ${end}`
+                        })()}
                       </div>
                     </div>
                     <div className="text-sm text-gray-600">
-                      {formatCurrency(run.total_gross)} for {run.employee_count} employees
+                      {formatCurrency((run as any).total_gross ?? (run as any).totalAmount)} for {run.employee_count} employees
                     </div>
                     <div className="text-xs text-gray-500 mt-1">
-                      Scheduled: {formatDate(run.pay_date)}
+                      Scheduled: {formatDate((run as any).pay_date ?? (run as any).payDate)}
                     </div>
                   </div>
                   <div className="flex items-center gap-2 ml-4">

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -160,9 +160,42 @@ import RunDetailPanel from '@frontend/components/payroll/run-detail-panel'
                 }}
                 className="space-y-4"
               >
-                <input name="start" type="date" className="w-full border p-2 rounded text-black" required />
-                <input name="end" type="date" className="w-full border p-2 rounded text-black" required />
-                <input name="payDate" type="date" className="w-full border p-2 rounded text-black" required />
+                <div>
+                  <label htmlFor="start" className="block text-sm font-medium mb-1">
+                    Period Start
+                  </label>
+                  <input
+                    id="start"
+                    name="start"
+                    type="date"
+                    className="w-full border p-2 rounded text-black"
+                    required
+                  />
+                </div>
+                <div>
+                  <label htmlFor="end" className="block text-sm font-medium mb-1">
+                    Period End
+                  </label>
+                  <input
+                    id="end"
+                    name="end"
+                    type="date"
+                    className="w-full border p-2 rounded text-black"
+                    required
+                  />
+                </div>
+                <div>
+                  <label htmlFor="payDate" className="block text-sm font-medium mb-1">
+                    Pay Date
+                  </label>
+                  <input
+                    id="payDate"
+                    name="payDate"
+                    type="date"
+                    className="w-full border p-2 rounded text-black"
+                    required
+                  />
+                </div>
                 <Button type="submit">Create</Button>
               </form>
             </DialogContent>

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -347,7 +347,11 @@ import RunModal from '@frontend/components/payroll/RunModal'
                     {run.status === 'pending' && (
                       <Button
                         size="sm"
-                        onClick={() => approvePayroll(run.id)}
+                        onClick={e => {
+                          // Prevent the row click handler from opening the drawer
+                          e.stopPropagation()
+                          approvePayroll(run.id)
+                        }}
                         className="flex items-center gap-1"
                       >
                         <CheckCircle className="h-4 w-4" />
@@ -357,7 +361,11 @@ import RunModal from '@frontend/components/payroll/RunModal'
                     {run.status === 'approved' && (
                       <Button
                         size="sm"
-                        onClick={() => processPayroll(run.id)}
+                        onClick={e => {
+                          // Prevent the row click handler from opening the drawer
+                          e.stopPropagation()
+                          processPayroll(run.id)
+                        }}
                         className="flex items-center gap-1"
                       >
                         <Play className="h-4 w-4" />

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -355,13 +355,15 @@ import RunDetailPanel from '@frontend/components/payroll/run-detail-panel'
                       <div className={`px-2 py-1 text-xs rounded ${getStatusColor(run.status)}`}>
                         {run.status}
                       </div>
-                      <div className="font-medium">{run.payPeriod}</div>
+                      <div className="font-medium">
+                        {run.pay_period_start} to {run.pay_period_end}
+                      </div>
                     </div>
                     <div className="text-sm text-gray-600">
-                      {formatCurrency(run.totalAmount)} for {run.employeeCount} employees
+                      {formatCurrency(run.total_gross)} for {run.employee_count} employees
                     </div>
                     <div className="text-xs text-gray-500 mt-1">
-                      Scheduled: {formatDate(run.scheduledDate)}
+                      Scheduled: {formatDate(run.pay_date)}
                     </div>
                   </div>
                   <div className="flex items-center gap-2 ml-4">

--- a/frontend/src/components/payroll/run-detail-panel.tsx
+++ b/frontend/src/components/payroll/run-detail-panel.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Dialog, DialogContent, DialogClose } from '@frontend/components/ui/dialog'
+import { Button } from '@frontend/components/ui/button'
+import { api } from '@frontend/lib/api'
+import { formatCurrency, formatDate } from '@frontend/lib/utils'
+import { useCompany } from '@frontend/context/CompanyContext'
+import type { PayrollRun } from '@frontend/types'
+
+interface RunDetailProps {
+  run: PayrollRun
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onUpdated: () => void
+}
+
+/** Drawer panel showing a single payroll run and actions */
+export default function RunDetailPanel({ run, open, onOpenChange, onUpdated }: RunDetailProps) {
+  const { companyId } = useCompany()
+  const [editMode, setEditMode] = useState(false)
+  const [start, setStart] = useState(run.payPeriod)
+  const [end, setEnd] = useState(run.payPeriod)
+  const [payDate, setPayDate] = useState(run.scheduledDate)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setEditMode(false)
+    setStart(run.payPeriod)
+    setEnd(run.payPeriod)
+    setPayDate(run.scheduledDate)
+  }, [open, run])
+
+  const save = async () => {
+    setLoading(true)
+    try {
+      await api.payroll.updateRun(
+        run.id,
+        { payPeriodStart: start, payPeriodEnd: end, payDate },
+        companyId || undefined
+      )
+      onUpdated()
+      setEditMode(false)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const remove = async () => {
+    if (!confirm('Discard this run?')) return
+    setLoading(true)
+    try {
+      await api.payroll.deleteRun(run.id, companyId || undefined)
+      onUpdated()
+      onOpenChange(false)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const approve = async () => {
+    setLoading(true)
+    try {
+      await api.payroll.approveRun(run.id, companyId || undefined)
+      onUpdated()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const revert = async () => {
+    setLoading(true)
+    try {
+      await api.payroll.revertRun(run.id, companyId || undefined)
+      onUpdated()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const process = async () => {
+    setLoading(true)
+    try {
+      await api.payroll.processRun(run.id, companyId || undefined)
+      onUpdated()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="fixed right-0 top-0 h-full w-full max-w-md rounded-none bg-white p-6 text-black">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">Payroll Run</h2>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm">Close</Button>
+          </DialogClose>
+        </div>
+
+        {editMode ? (
+          <form
+            onSubmit={e => {
+              e.preventDefault()
+              save()
+            }}
+            className="space-y-4"
+          >
+            <input
+              type="date"
+              value={start}
+              onChange={e => setStart(e.target.value)}
+              className="w-full border p-2 rounded"
+              required
+            />
+            <input
+              type="date"
+              value={end}
+              onChange={e => setEnd(e.target.value)}
+              className="w-full border p-2 rounded"
+              required
+            />
+            <input
+              type="date"
+              value={payDate}
+              onChange={e => setPayDate(e.target.value)}
+              className="w-full border p-2 rounded"
+              required
+            />
+            <div className="flex gap-2">
+              <Button type="submit" disabled={loading}>Save</Button>
+              <Button variant="outline" type="button" onClick={() => setEditMode(false)}>
+                Cancel
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <div className="space-y-2">
+            <div className="font-medium">Period: {run.payPeriod}</div>
+            <div className="text-sm">Pay Date: {formatDate(run.scheduledDate)}</div>
+            <div className="text-sm">Amount: {formatCurrency(run.totalAmount)}</div>
+            <div className="text-sm">Employees: {run.employeeCount}</div>
+            <div className="text-sm">Status: {run.status}</div>
+            <div className="flex gap-2 mt-4 flex-wrap">
+              {run.status === 'draft' && (
+                <>
+                  <Button size="sm" onClick={() => setEditMode(true)}>Edit</Button>
+                  <Button size="sm" variant="destructive" onClick={remove}>Discard</Button>
+                </>
+              )}
+              {run.status === 'pending' && (
+                <Button size="sm" onClick={approve}>Approve</Button>
+              )}
+              {run.status === 'approved' && (
+                <>
+                  <Button size="sm" onClick={process}>Process</Button>
+                  <Button size="sm" variant="outline" onClick={revert}>Revert</Button>
+                </>
+              )}
+              {run.status === 'processed' && (
+                <span className="text-green-600 flex items-center">Processed</span>
+              )}
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/payroll/run-detail-panel.tsx
+++ b/frontend/src/components/payroll/run-detail-panel.tsx
@@ -19,17 +19,17 @@ interface RunDetailProps {
 export default function RunDetailPanel({ run, open, onOpenChange, onUpdated }: RunDetailProps) {
   const { companyId } = useCompany()
   const [editMode, setEditMode] = useState(false)
-  const [start, setStart] = useState(run.payPeriod)
-  const [end, setEnd] = useState(run.payPeriod)
-  const [payDate, setPayDate] = useState(run.scheduledDate)
+  const [start, setStart] = useState(run.pay_period_start)
+  const [end, setEnd] = useState(run.pay_period_end)
+  const [payDate, setPayDate] = useState(run.pay_date)
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     if (!open) return
     setEditMode(false)
-    setStart(run.payPeriod)
-    setEnd(run.payPeriod)
-    setPayDate(run.scheduledDate)
+    setStart(run.pay_period_start)
+    setEnd(run.pay_period_end)
+    setPayDate(run.pay_date)
   }, [open, run])
 
   const save = async () => {
@@ -137,10 +137,12 @@ export default function RunDetailPanel({ run, open, onOpenChange, onUpdated }: R
           </form>
         ) : (
           <div className="space-y-2">
-            <div className="font-medium">Period: {run.payPeriod}</div>
-            <div className="text-sm">Pay Date: {formatDate(run.scheduledDate)}</div>
-            <div className="text-sm">Amount: {formatCurrency(run.totalAmount)}</div>
-            <div className="text-sm">Employees: {run.employeeCount}</div>
+            <div className="font-medium">
+              Period: {run.pay_period_start} to {run.pay_period_end}
+            </div>
+            <div className="text-sm">Pay Date: {formatDate(run.pay_date)}</div>
+            <div className="text-sm">Amount: {formatCurrency(run.total_gross)}</div>
+            <div className="text-sm">Employees: {run.employee_count}</div>
             <div className="text-sm">Status: {run.status}</div>
             <div className="flex gap-2 mt-4 flex-wrap">
               {run.status === 'draft' && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -83,6 +83,11 @@ export const api = {
   // Payroll endpoints
   payroll: {
     getRuns: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/runs?companyId=${companyId}`),
+    createRun: (data: Record<string, unknown>) => apiClient.post('/api/payroll/runs', data),
+    updateRun: (id: string, data: Record<string, unknown>, companyId: string = 'demo-company') =>
+      apiClient.put(`/api/payroll/runs/${id}?companyId=${companyId}`, data),
+    deleteRun: (id: string, companyId: string = 'demo-company') =>
+      apiClient.delete(`/api/payroll/runs/${id}?companyId=${companyId}`),
     getEmployees: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/employees?companyId=${companyId}`),
     getSummary: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/summary?companyId=${companyId}`),
     addEmployee: (data: Record<string, unknown>) => apiClient.post('/api/payroll/employees', data),
@@ -99,6 +104,7 @@ export const api = {
     getUpcoming: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/upcoming?companyId=${companyId}`),
     getStats: (companyId: string = 'demo-company') => apiClient.get(`/api/payroll/stats?companyId=${companyId}`),
     approveRun: (runId: string, companyId: string = 'demo-company') => apiClient.post(`/api/payroll/runs/${runId}/approve`, { companyId }),
+    revertRun: (runId: string, companyId: string = 'demo-company') => apiClient.post(`/api/payroll/runs/${runId}/revert`, { companyId }),
     processRun: (runId: string, companyId: string = 'demo-company') => apiClient.post(`/api/payroll/runs/${runId}/process`, { companyId }),
   },
   

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -54,7 +54,7 @@ export interface PayrollRun {
   total_taxes: number
   total_deductions: number
   employee_count: number
-  check_payroll_id?: string | null
+  check_payroll_id: string
   created_at?: string
   updated_at?: string
   entries: PayrollEntry[]

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -43,11 +43,20 @@ export interface CashFlowProjection {
 
 export interface PayrollRun {
   id: string
-  payPeriod: string
-  scheduledDate: string
-  status: 'draft' | 'pending' | 'approved' | 'processed' | 'failed'
-  totalAmount: number
-  employeeCount: number
+  company_id: string
+  run_number: string
+  pay_period_start: string
+  pay_period_end: string
+  pay_date: string
+  status: 'draft' | 'pending' | 'approved' | 'processed' | 'cancelled'
+  total_gross: number
+  total_net: number
+  total_taxes: number
+  total_deductions: number
+  employee_count: number
+  check_payroll_id?: string | null
+  created_at?: string
+  updated_at?: string
   entries: PayrollEntry[]
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -35,9 +35,21 @@ export interface BankAccount {
  * Payroll run result
  */
 export interface PayrollRun {
-  payrollRunId: string;
-  status: 'pending' | 'paid' | string;
+  id: string;
+  company_id: string;
+  check_payroll_id?: string | null;
+  run_number: string;
+  pay_period_start: string;
+  pay_period_end: string;
+  pay_date: string;
+  status: 'draft' | 'pending' | 'approved' | 'processed' | 'cancelled';
+  total_gross: number;
+  total_net: number;
+  total_taxes: number;
+  total_deductions: number;
+  employee_count: number;
   created_at?: string;
+  updated_at?: string;
 }
 
 /**

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -37,7 +37,7 @@ export interface BankAccount {
 export interface PayrollRun {
   id: string;
   company_id: string;
-  check_payroll_id?: string | null;
+  check_payroll_id: string;
   run_number: string;
   pay_period_start: string;
   pay_period_end: string;


### PR DESCRIPTION
## Summary
- add backend endpoints for payroll run lifecycle
- extend API client for new payroll run operations
- create RunDetailPanel component for viewing/updating runs
- enable run creation and filtering in dashboard

## Testing
- `pnpm lint` *(fails: numerous existing lint errors)*
- `pnpm test --coverage` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687a938e53e08328b367e68726abde00