### PR TITLE
Add Add Funds sandbox feature

### DIFF
--- a/frontend/src/components/banking/AddFundsModal.tsx
+++ b/frontend/src/components/banking/AddFundsModal.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogClose } from '@frontend/components/ui/dialog'
+import { Button } from '@frontend/components/ui/button'
+import { api } from '@frontend/lib/api'
+import { mutate } from 'swr'
+
+interface AddFundsModalProps {
+  accountId: string
+  companyId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onStarted?: () => void
+  onFinished?: () => void
+}
+
+export default function AddFundsModal({ accountId, companyId, open, onOpenChange, onStarted, onFinished }: AddFundsModalProps) {
+  const [amount, setAmount] = useState(0)
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [name, setName] = useState('Manual deposit')
+  const [loading, setLoading] = useState(false)
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (amount <= 0) {
+      alert('Enter a positive amount.')
+      return
+    }
+    setLoading(true)
+    onStarted?.()
+    try {
+      await api.banking.addFunds(accountId, amount, companyId, name, date)
+      await Promise.all([
+        mutate(`/api/banking/balances?companyId=${companyId}`),
+        mutate(`/api/banking/transactions?companyId=${companyId}`),
+        mutate(`/api/banking/accounts?companyId=${companyId}`),
+      ])
+      onOpenChange(false)
+    } catch (err: any) {
+      alert(err?.message || 'Deposit failed')
+    } finally {
+      setLoading(false)
+      onFinished?.()
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="text-black">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">Add Funds</h2>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm">Close</Button>
+          </DialogClose>
+        </div>
+        <form onSubmit={submit} className="space-y-4">
+          <input
+            type="number"
+            step="0.01"
+            value={amount}
+            onChange={e => setAmount(parseFloat(e.target.value))}
+            className="w-full border p-2 rounded text-black"
+            placeholder="Amount"
+            required
+          />
+          <input
+            type="date"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+            className="w-full border p-2 rounded text-black"
+          />
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            className="w-full border p-2 rounded text-black"
+            placeholder="Description"
+          />
+          <Button type="submit" disabled={loading} className="w-full">
+            {loading ? 'Adding...' : 'Add Funds'}
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/banking/banking-dashboard.tsx
+++ b/frontend/src/components/banking/banking-dashboard.tsx
@@ -150,6 +150,22 @@ export default function BankingDashboard() {
     }, 0)
   }
 
+  const addFunds = async (accountId: string) => {
+    const amountStr = window.prompt('Amount to deposit:')
+    if (!amountStr) return
+    const amount = parseFloat(amountStr)
+    if (isNaN(amount) || amount <= 0) {
+      alert('Invalid amount')
+      return
+    }
+    try {
+      await api.banking.addFunds(accountId, amount, companyId)
+      await Promise.all([mutateAccounts(), mutateTransactions()])
+    } catch (error) {
+      console.error('Failed to add funds:', error)
+    }
+  }
+
   if (loading) {
     return (
       <div className="space-y-6">
@@ -290,8 +306,8 @@ export default function BankingDashboard() {
                       <div className="text-xs text-gray-500 dark:text-gray-400 capitalize">{account.type} account</div>
                     </div>
                   </div>
-                  <div className="text-right">
-                    <div className={`text-lg font-semibold ${account.balance >= 0 ? 'text-green-600' : 'text-red-600'}`}> 
+                  <div className="text-right space-y-1">
+                    <div className={`text-lg font-semibold ${account.balance >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                       {formatCurrency((account as any).balance)}
                     </div>
                     <div className="text-sm text-gray-600 dark:text-gray-400">
@@ -300,6 +316,9 @@ export default function BankingDashboard() {
                     <div className="text-xs text-gray-500 dark:text-gray-400">
                       Updated: {formatDate((account as any).lastUpdated)}
                     </div>
+                    <Button size="sm" variant="outline" onClick={() => addFunds(account.id)}>
+                      Add Funds
+                    </Button>
                   </div>
                 </div>
               ))

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -111,8 +111,20 @@ export const api = {
     refresh: (companyId: string = 'demo-company') => apiClient.post('/api/banking/refresh', { companyId }),
     linkToken: (userId: string = 'demo-user', companyId: string = 'demo-company') => apiClient.post('/api/banking/link-token', { userId, companyId }),
     exchangeToken: (publicToken: string, companyId: string = 'demo-company') => apiClient.post('/api/banking/exchange-token', { publicToken, companyId }),
-    addFunds: (accountId: string, amount: number, companyId: string = 'demo-company') =>
-      apiClient.post('/api/banking/deposit', { accountId, amount, companyId }),
+    addFunds: (
+      accountId: string,
+      amount: number,
+      companyId: string = 'demo-company',
+      name: string,
+      date: string
+    ) =>
+      apiClient.post('/api/banking/deposit', {
+        accountId,
+        amount,
+        companyId,
+        name,
+        date,
+      }),
   },
   
   // Monitoring endpoints

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -111,6 +111,8 @@ export const api = {
     refresh: (companyId: string = 'demo-company') => apiClient.post('/api/banking/refresh', { companyId }),
     linkToken: (userId: string = 'demo-user', companyId: string = 'demo-company') => apiClient.post('/api/banking/link-token', { userId, companyId }),
     exchangeToken: (publicToken: string, companyId: string = 'demo-company') => apiClient.post('/api/banking/exchange-token', { publicToken, companyId }),
+    addFunds: (accountId: string, amount: number, companyId: string = 'demo-company') =>
+      apiClient.post('/api/banking/deposit', { accountId, amount, companyId }),
   },
   
   // Monitoring endpoints


### PR DESCRIPTION
## Summary
- allow sandbox deposit via `/api/banking/deposit`
- expose `addFunds` helper in API client
- enable Add Funds button per account in banking dashboard

## Testing
- `pnpm lint` *(fails: React Hooks ordering and other issues)*
- `pnpm test --coverage` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687d4fb57e6c8328bf06ba17fa17c548