### PR TITLE
Fix payroll edit drawer interaction

### DIFF
--- a/frontend/src/components/payroll/RunDrawer.tsx
+++ b/frontend/src/components/payroll/RunDrawer.tsx
@@ -96,7 +96,15 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
             <div className="flex gap-2 mt-4 flex-wrap">
               {['draft', 'pending'].includes(run.status) && (
                 <>
-                  <Button size="sm" onClick={() => setEditing(true)} disabled={loading}>
+                  <Button
+                    size="sm"
+                    onClick={() => {
+                      // Close drawer so the edit modal is unobstructed
+                      setEditing(true)
+                      onOpenChange(false)
+                    }}
+                    disabled={loading}
+                  >
                     {loading ? <Loader className="h-4 w-4 animate-spin" /> : 'Edit'}
                   </Button>
                   <Button size="sm" variant="destructive" onClick={remove} disabled={loading}>


### PR DESCRIPTION
## Summary
- close the payroll run drawer before opening the edit modal

## Testing
- `pnpm lint`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_687d688d1e7c8328a8cec8c4f20535c9