### PR TITLE
Fix payroll edit modal

### DIFF
--- a/frontend/src/components/payroll/RunDrawer.tsx
+++ b/frontend/src/components/payroll/RunDrawer.tsx
@@ -8,19 +8,20 @@ import { formatCurrency, formatDate } from '@frontend/lib/utils'
 import { Loader } from 'lucide-react'
 import { useCompany } from '@frontend/context/CompanyContext'
 import type { PayrollRun } from '@frontend/types'
-import RunModal from './RunModal'
+// The edit modal is handled at the dashboard level to avoid nested dialogs
 
 interface RunDetailProps {
   run: PayrollRun
   open: boolean
   onOpenChange: (open: boolean) => void
   onUpdated: () => void
+  /** Trigger editing of this run */
+  onEdit: (run: PayrollRun) => void
 }
 
 /** Drawer panel showing a single payroll run and actions */
-export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDetailProps) {
+export default function RunDrawer({ run, open, onOpenChange, onUpdated, onEdit }: RunDetailProps) {
   const { companyId } = useCompany()
-  const [editing, setEditing] = useState(false)
   const [loading, setLoading] = useState(false)
 
   const remove = async () => {
@@ -96,7 +97,14 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
             <div className="flex gap-2 mt-4 flex-wrap">
               {['draft', 'pending'].includes(run.status) && (
                 <>
-                  <Button size="sm" onClick={() => setEditing(true)} disabled={loading}>
+                  <Button
+                    size="sm"
+                    onClick={() => {
+                      onOpenChange(false)
+                      onEdit(run)
+                    }}
+                    disabled={loading}
+                  >
                     {loading ? <Loader className="h-4 w-4 animate-spin" /> : 'Edit'}
                   </Button>
                   <Button size="sm" variant="destructive" onClick={remove} disabled={loading}>
@@ -126,12 +134,6 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
           </div>
         </DialogContent>
       </Dialog>
-      <RunModal
-        open={editing}
-        onOpenChange={setEditing}
-        onSaved={onUpdated}
-        run={run}
-      />
     </>
   )
 }

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -34,10 +34,12 @@ import RunModal from '@frontend/components/payroll/RunModal'
     const [open, setOpen] = useState(false)
     const [detailOpen, setDetailOpen] = useState(false)
     const [selected, setSelected] = useState<Employee | null>(null)
-    const [runPanelOpen, setRunPanelOpen] = useState(false)
-    const [selectedRun, setSelectedRun] = useState<PayrollRun | null>(null)
-    const [createOpen, setCreateOpen] = useState(false)
-    const [filter, setFilter] = useState<'all' | 'pending' | 'approved' | 'processed' | 'draft'>('all')
+  const [runPanelOpen, setRunPanelOpen] = useState(false)
+  const [selectedRun, setSelectedRun] = useState<PayrollRun | null>(null)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editRun, setEditRun] = useState<PayrollRun | null>(null)
+  const [editOpen, setEditOpen] = useState(false)
+  const [filter, setFilter] = useState<'all' | 'pending' | 'approved' | 'processed' | 'draft'>('all')
 
     const fetcher = (url: string) => apiClient.get(url).then(res => res.data)
 
@@ -446,6 +448,10 @@ import RunModal from '@frontend/components/payroll/RunModal'
           onUpdated={async () => {
             await Promise.all([mutRuns(), mutSum()])
           }}
+          onEdit={run => {
+            setEditRun(run)
+            setEditOpen(true)
+          }}
         />
       )}
       <RunModal
@@ -455,6 +461,19 @@ import RunModal from '@frontend/components/payroll/RunModal'
           await Promise.all([mutRuns(), mutSum()])
         }}
       />
+      {editRun && (
+        <RunModal
+          open={editOpen}
+          onOpenChange={o => {
+            setEditOpen(o)
+            if (!o) setEditRun(null)
+          }}
+          onSaved={async () => {
+            await Promise.all([mutRuns(), mutSum()])
+          }}
+          run={editRun}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- delegate editing modals to dashboard instead of nested dialogs
- pass run edit handler from dashboard to RunDrawer

## Testing
- `pnpm lint` *(fails: unexpected any, react-hooks issues)*
- `pnpm test --coverage` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687d688d1e7c8328a8cec8c4f20535c9