### PR TITLE
Implement dark mode styling with CSS variables

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,26 +1,37 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+  --c-bg: #0D1117;
+  --c-surface-1: #161B22;
+  --c-surface-2: #1E242C;
+  --c-surface-3: #21262D;
+  --c-surface-4: #30363D;
+  --c-border: #3B4149;
+  --c-overlay: rgba(13,17,23,.60);
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+  --c-text: #E6EDF3;
+  --c-text-subtle: #8B949E;
+  --c-text-disabled: #6E7681;
+
+  --c-accent: #7C3AED;
+  --c-accent-hover: #9F57FF;
+  --c-accent-bg: rgba(124,58,237,.15);
+
+  --c-success: #22C55E;
+  --c-success-hover: #4ADE80;
+  --c-warning: #EAB308;
+  --c-warning-hover: #FACC15;
+  --c-error: #EF4444;
+  --c-error-hover: #F87171;
+  --c-info: #0EA5E9;
+  --c-info-hover: #38BDF8;
+
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  background: var(--background);
-  color: var(--foreground);
+  background: var(--c-bg);
+  color: var(--c-text);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -24,9 +24,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased dark:bg-gray-900 dark:text-gray-100`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[var(--c-bg)] text-[var(--c-text)]`}
       >
         <CompanyProvider>{children}</CompanyProvider>
       </body>

--- a/frontend/src/components/banking/banking-dashboard.tsx
+++ b/frontend/src/components/banking/banking-dashboard.tsx
@@ -31,6 +31,9 @@ const fetcher = (url: string) =>
  * Dashboard view for banking data.
  * Shows linked accounts and recent transactions using SWR to poll the backend.
  */
+/**
+ * Dashboard to manage linked bank accounts and view recent transactions.
+ */
 export default function BankingDashboard() {
   const { companyId } = useCompany()
 
@@ -157,8 +160,8 @@ export default function BankingDashboard() {
           {[...Array(4)].map((_, i) => (
             <Card key={i} className="animate-pulse">
               <CardHeader>
-                <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-                <div className="h-8 bg-gray-200 rounded w-1/2"></div>
+                <div className="h-4 rounded w-3/4 bg-[var(--c-surface-3)]"></div>
+                <div className="h-8 rounded w-1/2 bg-[var(--c-surface-3)]"></div>
               </CardHeader>
             </Card>
           ))}
@@ -171,8 +174,8 @@ export default function BankingDashboard() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Banking</h1>
-          <p className="text-gray-600">Manage bank accounts and transactions</p>
+          <h1 className="text-2xl font-bold text-[var(--c-text)]">Banking</h1>
+          <p className="text-[var(--c-text-subtle)]">Manage bank accounts and transactions</p>
         </div>
         <div className="flex gap-2">
           <Button 
@@ -201,61 +204,61 @@ export default function BankingDashboard() {
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-        <Card className="dark:bg-gray-800">
+        <Card className="bg-[var(--c-surface-1)]">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Total Balance</CardTitle>
-            <DollarSign className="h-4 w-4 text-green-600" />
+            <DollarSign className="h-4 w-4 text-[var(--c-success)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-green-600">
+            <div className="text-2xl font-bold text-[var(--c-success)]">
               {formatCurrency(getTotalBalance())}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               Across {accounts?.length || 0} accounts
             </p>
           </CardContent>
         </Card>
 
-        <Card className="dark:bg-gray-800">
+        <Card className="bg-[var(--c-surface-1)]">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Available Funds</CardTitle>
-            <CreditCard className="h-4 w-4 text-blue-600" />
+            <CreditCard className="h-4 w-4 text-[var(--c-info)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-blue-600">
+            <div className="text-2xl font-bold text-[var(--c-info)]">
               {formatCurrency(getTotalAvailable())}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               Available to spend
             </p>
           </CardContent>
         </Card>
 
-        <Card className="dark:bg-gray-800">
+        <Card className="bg-[var(--c-surface-1)]">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Connection Status</CardTitle>
-            <Building className="h-4 w-4 text-green-600" />
+            <Building className="h-4 w-4 text-[var(--c-success)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-green-600">
+            <div className="text-2xl font-bold text-[var(--c-success)]">
               {status?.connected ? 'Connected' : 'Disconnected'}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               Last sync: {status?.lastSync ? formatDate(status.lastSync) : 'Never'}
             </p>
           </CardContent>
         </Card>
 
-        <Card className="dark:bg-gray-800">
+        <Card className="bg-[var(--c-surface-1)]">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Recent Activity</CardTitle>
-            <Calendar className="h-4 w-4 text-purple-600" />
+            <Calendar className="h-4 w-4 text-[var(--c-accent)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-purple-600">
+            <div className="text-2xl font-bold text-[var(--c-accent)]">
               {transactions?.length || 0}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               Transactions this month
             </p>
           </CardContent>
@@ -263,7 +266,7 @@ export default function BankingDashboard() {
       </div>
 
       {/* Bank Accounts */}
-      <Card className="dark:bg-gray-800">
+      <Card className="bg-[var(--c-surface-1)]">
         <CardHeader>
           <CardTitle>Bank Accounts</CardTitle>
           <CardDescription>Connected bank accounts and balances</CardDescription>
@@ -279,25 +282,28 @@ export default function BankingDashboard() {
               </div>
             ) : (
               accounts.map(account => (
-                <div key={account.id} className="flex items-center justify-between p-4 border rounded dark:border-gray-700">
+                <div
+                  key={account.id}
+                  className="flex items-center justify-between p-4 border border-[var(--c-border)] rounded bg-[var(--c-surface-1)]"
+                >
                   <div className="flex items-center gap-4">
-                    <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded">
-                      <CreditCard className="h-6 w-6 text-gray-600 dark:text-gray-300" />
+                    <div className="rounded p-2 bg-[var(--c-surface-2)]">
+                      <CreditCard className="h-6 w-6 text-[var(--c-text-subtle)]" />
                     </div>
                     <div>
                       <div className="font-medium">{account.name}</div>
-                      <div className="text-sm text-gray-600 dark:text-gray-400">{account.institutionName}</div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400 capitalize">{account.type} account</div>
+                      <div className="text-sm text-[var(--c-text-subtle)]">{account.institutionName}</div>
+                      <div className="text-xs capitalize text-[var(--c-text-disabled)]">{account.type} account</div>
                     </div>
                   </div>
                   <div className="text-right">
-                    <div className={`text-lg font-semibold ${account.balance >= 0 ? 'text-green-600' : 'text-red-600'}`}> 
+                    <div className={`text-lg font-semibold ${account.balance >= 0 ? 'text-[var(--c-success)]' : 'text-[var(--c-error)]'}`}>
                       {formatCurrency((account as any).balance)}
                     </div>
-                    <div className="text-sm text-gray-600 dark:text-gray-400">
+                    <div className="text-sm text-[var(--c-text-subtle)]">
                       Available: {formatCurrency((account as any).availableBalance)}
                     </div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                    <div className="text-xs text-[var(--c-text-disabled)]">
                       Updated: {formatDate((account as any).lastUpdated)}
                     </div>
                   </div>
@@ -309,7 +315,7 @@ export default function BankingDashboard() {
       </Card>
 
       {/* Recent Transactions */}
-      <Card className="dark:bg-gray-800">
+      <Card className="bg-[var(--c-surface-1)]">
         <CardHeader>
           <CardTitle>Recent Transactions</CardTitle>
           <CardDescription>
@@ -319,31 +325,38 @@ export default function BankingDashboard() {
         <CardContent>
           <div className="space-y-4">
             {!transactions || transactions.length === 0 ? (
-              <div className="p-4 text-center text-gray-500 border rounded dark:border-gray-700">
+              <div className="p-4 text-center text-[var(--c-text-disabled)] border border-[var(--c-border)] rounded">
                 No recent transactions
               </div>
             ) : (
               transactions.map((transaction) => (
-                <div key={transaction.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
+                <div
+                  key={transaction.id}
+                  className="flex items-center justify-between p-3 rounded border border-[var(--c-border)] bg-[var(--c-surface-1)]"
+                >
                   <div className="flex items-center gap-3">
-                    <div className={`p-2 rounded ${transaction.type === 'credit' ? 'bg-green-100' : 'bg-red-100'}`}>
+                    <div
+                      className={`p-2 rounded ${transaction.type === 'credit' ? 'bg-[var(--c-success)]/20' : 'bg-[var(--c-error)]/20'}`}
+                    >
                       {transaction.type === 'credit' ? (
-                        <TrendingUp className="h-4 w-4 text-green-600" />
+                        <TrendingUp className="h-4 w-4 text-[var(--c-success)]" />
                       ) : (
-                        <TrendingDown className="h-4 w-4 text-red-600" />
+                        <TrendingDown className="h-4 w-4 text-[var(--c-error)]" />
                       )}
                     </div>
                     <div>
                       <div className="font-medium">{transaction.description}</div>
-                      <div className="text-sm text-gray-600">{transaction.category}</div>
-                      <div className="text-xs text-gray-500">{formatDate(transaction.date)}</div>
+                      <div className="text-sm text-[var(--c-text-subtle)]">{transaction.category}</div>
+                      <div className="text-xs text-[var(--c-text-disabled)]">{formatDate(transaction.date)}</div>
                     </div>
                   </div>
                   <div className="text-right">
-                    <div className={`font-semibold ${transaction.amount >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    <div
+                      className={`font-semibold ${transaction.amount >= 0 ? 'text-[var(--c-success)]' : 'text-[var(--c-error)]'}`}
+                    >
                       {transaction.amount >= 0 ? '+' : ''}{formatCurrency(transaction.amount)}
                     </div>
-                    <div className="text-xs text-gray-500">
+                    <div className="text-xs text-[var(--c-text-disabled)]">
                       Account: {accounts?.find(a => a.id === transaction.accountId)?.name || 'Unknown'}
                     </div>
                   </div>

--- a/frontend/src/components/cash-flow/cash-flow-dashboard.tsx
+++ b/frontend/src/components/cash-flow/cash-flow-dashboard.tsx
@@ -18,6 +18,9 @@ import {
 } from 'lucide-react'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar } from 'recharts'
 
+/**
+ * Dashboard view showing cash flow summaries and projections.
+ */
 export default function CashFlowDashboard() {
   const { companyId } = useCompany()
 
@@ -96,27 +99,31 @@ export default function CashFlowDashboard() {
       <div className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
           {[...Array(4)].map((_, i) => (
-            <Card key={i} className="animate-pulse">
-              <CardHeader>
-                <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-                <div className="h-8 bg-gray-200 rounded w-1/2"></div>
-              </CardHeader>
-            </Card>
+          <Card key={i} className="animate-pulse">
+            <CardHeader>
+              <div className="h-4 rounded w-3/4 bg-[var(--c-surface-3)]"></div>
+              <div className="h-8 rounded w-1/2 bg-[var(--c-surface-3)]"></div>
+            </CardHeader>
+          </Card>
           ))}
         </div>
       </div>
     )
   }
 
-  const runwayColor = (summary?.runway || 0) > 3 ? 'text-green-600' : 
-                     (summary?.runway || 0) > 1 ? 'text-yellow-600' : 'text-red-600'
+  const runwayColor =
+    (summary?.runway || 0) > 3
+      ? 'text-[var(--c-success)]'
+      : (summary?.runway || 0) > 1
+      ? 'text-[var(--c-warning)]'
+      : 'text-[var(--c-error)]'
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Cash Flow</h1>
-          <p className="text-gray-600">Monitor and forecast cash flow</p>
+          <h1 className="text-2xl font-bold text-[var(--c-text)]">Cash Flow</h1>
+          <p className="text-[var(--c-text-subtle)]">Monitor and forecast cash flow</p>
         </div>
         <Button 
           onClick={recalculateProjections} 
@@ -133,13 +140,13 @@ export default function CashFlowDashboard() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Current Balance</CardTitle>
-            <DollarSign className="h-4 w-4 text-green-600" />
+            <DollarSign className="h-4 w-4 text-[var(--c-success)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-green-600">
+            <div className="text-2xl font-bold text-[var(--c-success)]">
               {formatCurrency(summary?.currentBalance || 0)}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               Available funds
             </p>
           </CardContent>
@@ -148,13 +155,13 @@ export default function CashFlowDashboard() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Projected Balance</CardTitle>
-            <TrendingUp className="h-4 w-4 text-blue-600" />
+            <TrendingUp className="h-4 w-4 text-[var(--c-info)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-blue-600">
+            <div className="text-2xl font-bold text-[var(--c-info)]">
               {formatCurrency(summary?.projectedBalance || 0)}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               30-day projection
             </p>
           </CardContent>
@@ -163,13 +170,13 @@ export default function CashFlowDashboard() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Monthly Burn Rate</CardTitle>
-            <TrendingDown className="h-4 w-4 text-red-600" />
+            <TrendingDown className="h-4 w-4 text-[var(--c-error)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-red-600">
+            <div className="text-2xl font-bold text-[var(--c-error)]">
               {formatCurrency(summary?.burnRate || 0)}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               Average monthly expenses
             </p>
           </CardContent>
@@ -184,7 +191,7 @@ export default function CashFlowDashboard() {
             <div className={`text-2xl font-bold ${runwayColor}`}>
               {summary?.runway?.toFixed(1) || '0.0'} months
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               At current burn rate
             </p>
           </CardContent>
@@ -305,16 +312,21 @@ export default function CashFlowDashboard() {
               { date: '2025-01-06', description: 'Software Subscriptions', amount: -2500, type: 'expense' },
               { date: '2025-01-05', description: 'Client Payment - XYZ Ltd', amount: 15000, type: 'income' }
             ].map((transaction, index) => (
-              <div key={index} className="flex items-center justify-between p-3 bg-gray-50 rounded">
+              <div
+                key={index}
+                className="flex items-center justify-between p-3 rounded border border-[var(--c-border)] bg-[var(--c-surface-1)]"
+              >
                 <div>
                   <div className="font-medium">{transaction.description}</div>
-                  <div className="text-sm text-gray-600">{formatDate(transaction.date)}</div>
+                  <div className="text-sm text-[var(--c-text-subtle)]">{formatDate(transaction.date)}</div>
                 </div>
                 <div className="text-right">
-                  <div className={`font-semibold ${transaction.amount > 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  <div
+                    className={`font-semibold ${transaction.amount > 0 ? 'text-[var(--c-success)]' : 'text-[var(--c-error)]'}`}
+                  >
                     {transaction.amount > 0 ? '+' : ''}{formatCurrency(transaction.amount)}
                   </div>
-                  <div className="text-sm text-gray-500 capitalize">{transaction.type}</div>
+                  <div className="text-sm capitalize text-[var(--c-text-disabled)]">{transaction.type}</div>
                 </div>
               </div>
             ))}

--- a/frontend/src/components/layout/dashboard-layout.tsx
+++ b/frontend/src/components/layout/dashboard-layout.tsx
@@ -38,21 +38,21 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const pathname = usePathname()
 
   return (
-    <div className="flex h-screen bg-gray-50">
+    <div className="flex h-screen bg-[var(--c-bg)]">
       {/* Mobile sidebar */}
       <div className={cn(
         "fixed inset-0 z-40 lg:hidden",
         sidebarOpen ? "block" : "hidden"
       )}>
-        <div className="fixed inset-0 bg-gray-600 bg-opacity-75" onClick={() => setSidebarOpen(false)} />
-        <div className="relative flex w-full max-w-xs flex-col bg-white">
+        <div className="fixed inset-0 bg-[var(--c-overlay)]" onClick={() => setSidebarOpen(false)} />
+        <div className="relative flex w-full max-w-xs flex-col bg-[var(--c-surface-1)]">
           <div className="absolute right-0 top-0 -mr-12 pt-2">
             <button
               type="button"
-              className="ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
+              className="ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-[var(--c-accent)]"
               onClick={() => setSidebarOpen(false)}
             >
-              <X className="h-6 w-6 text-white" />
+              <X className="h-6 w-6 text-[var(--c-text)]" />
             </button>
           </div>
           <Sidebar />
@@ -65,11 +65,11 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       </div>
 
       {/* Main content */}
-      <div className="flex flex-1 flex-col lg:pl-64">
-        <div className="sticky top-0 z-10 flex h-16 flex-shrink-0 bg-white shadow">
+        <div className="flex flex-1 flex-col lg:pl-64">
+          <div className="sticky top-0 z-10 flex h-16 flex-shrink-0 bg-[var(--c-surface-1)] border-b border-[var(--c-border)] shadow">
           <button
             type="button"
-            className="border-r border-gray-200 px-4 text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500 lg:hidden"
+              className="border-r border-[var(--c-border)] px-4 text-[var(--c-text-subtle)] focus:outline-none focus:ring-2 focus:ring-inset focus:ring-[var(--c-accent)] lg:hidden"
             onClick={() => setSidebarOpen(true)}
           >
             <Menu className="h-6 w-6" />
@@ -77,17 +77,17 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           <div className="flex flex-1 justify-between px-4">
             <div className="flex flex-1">
               <div className="flex w-full md:ml-0">
-                <div className="relative w-full text-gray-400 focus-within:text-gray-600">
-                  <h1 className="text-xl font-semibold text-gray-900 py-4">
+                  <div className="relative w-full text-[var(--c-text-disabled)] focus-within:text-[var(--c-text-subtle)]">
+                    <h1 className="text-xl font-semibold text-[var(--c-text)] py-4">
                     Payroll Sentinel
                   </h1>
                 </div>
               </div>
             </div>
             <div className="ml-4 flex items-center md:ml-6">
-              <button
-                type="button"
-                className="rounded-full bg-white p-1 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                <button
+                  type="button"
+                  className="rounded-full bg-[var(--c-surface-2)] p-1 text-[var(--c-text-disabled)] hover:text-[var(--c-text-subtle)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2"
               >
                 <Bell className="h-6 w-6" />
               </button>
@@ -108,11 +108,11 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
   function Sidebar() {
     return (
-      <div className="flex min-h-0 flex-1 flex-col bg-white">
+      <div className="flex min-h-0 flex-1 flex-col bg-[var(--c-surface-1)]">
         <div className="flex flex-1 flex-col overflow-y-auto pt-5 pb-4">
           <div className="flex flex-shrink-0 items-center px-4">
-            <Shield className="h-8 w-8 text-indigo-600" />
-            <span className="ml-2 text-xl font-semibold text-gray-900">
+            <Shield className="h-8 w-8 text-[var(--c-accent)]" />
+            <span className="ml-2 text-xl font-semibold text-[var(--c-text)]">
               Payroll Sentinel
             </span>
           </div>
@@ -125,14 +125,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                   href={item.href}
                   className={cn(
                     isActive
-                      ? 'bg-indigo-50 text-indigo-700'
-                      : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900',
+                      ? 'bg-[var(--c-accent-bg)] text-[var(--c-accent)]'
+                      : 'text-[var(--c-text-subtle)] hover:bg-[var(--c-surface-3)] hover:text-[var(--c-text)]',
                     'group flex items-center px-2 py-2 text-sm font-medium rounded-md'
                   )}
                 >
                   <item.icon
                     className={cn(
-                      isActive ? 'text-indigo-500' : 'text-gray-400 group-hover:text-gray-500',
+                      isActive ? 'text-[var(--c-accent)]' : 'text-[var(--c-text-disabled)] group-hover:text-[var(--c-text-subtle)]',
                       'mr-3 h-6 w-6'
                     )}
                   />

--- a/frontend/src/components/payroll/RunDrawer.tsx
+++ b/frontend/src/components/payroll/RunDrawer.tsx
@@ -80,7 +80,7 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* Drawer-style content positioned on the right without the default modal transforms */}
       <DialogContent
-        className="fixed right-0 top-0 left-auto translate-x-0 translate-y-0 h-full w-full max-w-md rounded-none bg-white p-6 text-black"
+        className="fixed right-0 top-0 left-auto translate-x-0 translate-y-0 h-full w-full max-w-md rounded-none border-l border-[var(--c-border)] p-6 text-[var(--c-text)]"
       >
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-semibold">Payroll Run</h2>
@@ -148,7 +148,7 @@ export default function RunDrawer({ run, open, onOpenChange, onUpdated }: RunDet
                 </>
               )}
               {run.status === 'processed' && (
-                <span className="text-green-600 flex items-center">Processed</span>
+                <span className="text-[var(--c-success)] flex items-center">Processed</span>
               )}
             </div>
           </div>

--- a/frontend/src/components/payroll/RunModal.tsx
+++ b/frontend/src/components/payroll/RunModal.tsx
@@ -100,7 +100,7 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="text-black">
+      <DialogContent className="text-[var(--c-text)]">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-semibold">
             {isEdit ? 'Edit Payroll Run' : 'New Payroll Run'}
@@ -125,7 +125,7 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
               type="date"
               value={start}
               onChange={e => setStart(e.target.value)}
-              className="w-full border p-2 rounded"
+              className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
               required
             />
           </div>
@@ -138,7 +138,7 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
               type="date"
               value={end}
               onChange={e => setEnd(e.target.value)}
-              className="w-full border p-2 rounded"
+              className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
               required
             />
           </div>
@@ -151,7 +151,7 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
               type="date"
               value={payDate}
               onChange={e => setPayDate(e.target.value)}
-              className="w-full border p-2 rounded"
+              className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
               required
             />
           </div>
@@ -165,12 +165,12 @@ export default function RunModal({ open, onOpenChange, onSaved, run }: RunModalP
               step="0.01"
               value={gross}
               onChange={e => setGross(e.target.value)}
-              className="w-full border p-2 rounded"
+              className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
               required
             />
           </div>
           {employees && (
-            <div className="border p-2 rounded max-h-40 overflow-auto space-y-1">
+            <div className="border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 rounded max-h-40 overflow-auto space-y-1">
               <div className="flex justify-between mb-2 text-sm">
                 <button type="button" onClick={selectAll}>Select all</button>
                 <button type="button" onClick={deselectAll}>Deselect all</button>

--- a/frontend/src/components/payroll/employee-detail-panel.tsx
+++ b/frontend/src/components/payroll/employee-detail-panel.tsx
@@ -76,7 +76,9 @@ export default function EmployeeDetailPanel({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="fixed right-0 top-0 left-auto translate-x-0 translate-y-0 h-full w-full max-w-md rounded-none bg-white p-6 text-black">
+      <DialogContent
+        className="fixed right-0 top-0 left-auto translate-x-0 translate-y-0 h-full w-full max-w-md rounded-none border-l border-[var(--c-border)] p-6 text-[var(--c-text)]"
+      >
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-semibold">Employee Details</h2>
           <DialogClose asChild>
@@ -97,7 +99,7 @@ export default function EmployeeDetailPanel({
               value={title}
               placeholder="Title"
               onChange={e => setTitle(e.target.value)}
-              className="w-full border p-2 rounded text-black"
+            className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
               required
             />
             <datalist id="title-options">
@@ -110,7 +112,7 @@ export default function EmployeeDetailPanel({
               value={department}
               placeholder="Department"
               onChange={e => setDepartment(e.target.value)}
-              className="w-full border p-2 rounded text-black"
+            className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
             />
             <datalist id="department-options">
               {DEPARTMENTS.map(d => (
@@ -122,13 +124,13 @@ export default function EmployeeDetailPanel({
               step="0.01"
               value={salary}
               onChange={e => setSalary(parseFloat(e.target.value))}
-              className="w-full border p-2 rounded text-black"
+              className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
               required
             />
             <select
               value={status}
               onChange={e => setStatus(e.target.value)}
-              className="w-full border p-2 rounded text-black"
+              className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
             >
               <option value="active">active</option>
               <option value="inactive">inactive</option>

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -160,8 +160,8 @@ export default function PayrollDashboard() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Payroll</h1>
-          <p className="text-gray-600">Manage payroll runs and employees</p>
+          <h1 className="text-2xl font-bold text-[var(--c-text)]">Payroll</h1>
+          <p className="text-[var(--c-text-subtle)]">Manage payroll runs and employees</p>
         </div>
         <div className="flex gap-2">
           <Button
@@ -176,7 +176,7 @@ export default function PayrollDashboard() {
                 <span className="text-xl">➕</span> Add Employee
               </Button>
             </DialogTrigger>
-            <DialogContent className="text-black">
+            <DialogContent className="text-[var(--c-text)]">
               <div className="flex justify-between items-center mb-4">
                 <h2 className="text-lg font-semibold">Add Employee</h2>
                 <DialogClose asChild>
@@ -206,14 +206,14 @@ export default function PayrollDashboard() {
                 <input
                   name="name"
                   placeholder="Name"
-                  className="w-full border p-2 rounded text-black"
+                  className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
                   required
                 />
                 <input
                   list="title-options"
                   name="title"
                   placeholder="Title"
-                  className="w-full border p-2 rounded text-black"
+                  className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
                   required
                 />
                 <datalist id="title-options">
@@ -225,7 +225,7 @@ export default function PayrollDashboard() {
                   list="department-options"
                   name="department"
                   placeholder="Department"
-                  className="w-full border p-2 rounded text-black"
+                  className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
                 />
                 <datalist id="department-options">
                   {DEPARTMENTS.map((d) => (
@@ -237,12 +237,12 @@ export default function PayrollDashboard() {
                   type="number"
                   step="0.01"
                   placeholder="Salary"
-                  className="w-full border p-2 rounded text-black"
+                  className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
                   required
                 />
                 <select
                   name="status"
-                  className="w-full border p-2 rounded text-black"
+                  className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
                 >
                   <option value="active">active</option>
                   <option value="inactive">inactive</option>
@@ -278,67 +278,67 @@ export default function PayrollDashboard() {
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-        <Card className="dark:bg-gray-800">
+        <Card className="bg-[var(--c-surface-1)]">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
               Total Employees
             </CardTitle>
-            <Users className="h-4 w-4 text-blue-600" />
+            <Users className="h-4 w-4 text-[var(--c-info)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-blue-600">
+            <div className="text-2xl font-bold text-[var(--c-info)]">
               {summary?.totalEmployees || 0}
             </div>
-            <p className="text-xs text-gray-600 mt-1">Total employees</p>
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">Total employees</p>
           </CardContent>
         </Card>
 
-        <Card className="dark:bg-gray-800">
+        <Card className="bg-[var(--c-surface-1)]">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
               Monthly Payroll
             </CardTitle>
-            <DollarSign className="h-4 w-4 text-green-600" />
+            <DollarSign className="h-4 w-4 text-[var(--c-success)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-green-600">
+            <div className="text-2xl font-bold text-[var(--c-success)]">
               {summary ? formatCurrency(summary.monthlyPayroll) : "$0"}
             </div>
-            <p className="text-xs text-gray-600 mt-1">Total monthly cost</p>
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">Total monthly cost</p>
           </CardContent>
         </Card>
 
-        <Card className="dark:bg-gray-800">
+        <Card className="bg-[var(--c-surface-1)]">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Next Payroll</CardTitle>
-            <Calendar className="h-4 w-4 text-purple-600" />
+            <Calendar className="h-4 w-4 text-[var(--c-accent)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-purple-600">
+            <div className="text-2xl font-bold text-[var(--c-accent)]">
               {summary?.nextPayroll
                 ? formatDate(summary.nextPayroll)
                 : "Not scheduled"}
             </div>
-            <p className="text-xs text-gray-600 mt-1">Scheduled date</p>
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">Scheduled date</p>
           </CardContent>
         </Card>
 
-        <Card className="dark:bg-gray-800">
+        <Card className="bg-[var(--c-surface-1)]">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Pending Runs</CardTitle>
-            <Clock className="h-4 w-4 text-yellow-600" />
+            <Clock className="h-4 w-4 text-[var(--c-warning)]" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-yellow-600">
+            <div className="text-2xl font-bold text-[var(--c-warning)]">
               {summary?.pendingRuns ?? 0}
             </div>
-            <p className="text-xs text-gray-600 mt-1">Awaiting approval</p>
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">Awaiting approval</p>
           </CardContent>
         </Card>
       </div>
 
       {/* Payroll Runs */}
-      <Card className="dark:bg-gray-800">
+      <Card className="bg-[var(--c-surface-1)]">
         <CardHeader>
           <CardTitle>Payroll Runs</CardTitle>
           <CardDescription>Recent and upcoming payroll runs</CardDescription>
@@ -360,7 +360,7 @@ export default function PayrollDashboard() {
             {(payrollRuns?.data || []).filter((r) =>
               filter === "all" ? true : r.status === filter,
             ).length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
+              <div className="text-center py-8 text-[var(--c-text-disabled)]">
                 No payroll runs found
               </div>
             ) : (
@@ -371,7 +371,7 @@ export default function PayrollDashboard() {
                 .map((run: PayrollRun) => (
                   <div
                     key={run.id}
-                    className="flex items-center justify-between p-4 border rounded cursor-pointer hover:bg-gray-50"
+                  className="flex items-center justify-between p-4 border border-[var(--c-border)] rounded cursor-pointer hover:bg-[var(--c-surface-3)]"
                     onClick={() => {
                       setSelectedRun(run);
                       setRunPanelOpen(true);
@@ -394,13 +394,13 @@ export default function PayrollDashboard() {
                           })()}
                         </div>
                       </div>
-                      <div className="text-sm text-gray-600">
+                      <div className="text-sm text-[var(--c-text-subtle)]">
                         {formatCurrency(
                           (run as any).total_gross ?? (run as any).totalAmount,
                         )}{" "}
                         for {summary?.totalEmployees ?? run.employee_count} employees
                       </div>
-                      <div className="text-xs text-gray-500 mt-1">
+                      <div className="text-xs text-[var(--c-text-disabled)] mt-1">
                         Scheduled:{" "}
                         {formatDate(
                           (run as any).pay_date ?? (run as any).payDate,
@@ -437,7 +437,7 @@ export default function PayrollDashboard() {
                         </Button>
                       )}
                       {run.status === "processed" && (
-                        <CheckCircle className="h-5 w-5 text-green-600" />
+                        <CheckCircle className="h-5 w-5 text-[var(--c-success)]" />
                       )}
                     </div>
                   </div>
@@ -448,7 +448,7 @@ export default function PayrollDashboard() {
       </Card>
 
       {/* Employee List */}
-      <Card className="dark:bg-gray-800">
+      <Card className="bg-[var(--c-surface-1)]">
         <CardHeader>
           <CardTitle>Employees</CardTitle>
           <CardDescription>Active employee roster</CardDescription>
@@ -456,14 +456,14 @@ export default function PayrollDashboard() {
         <CardContent>
           <div className="space-y-4">
             {(employees?.data || []).length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
+              <div className="text-center py-8 text-[var(--c-text-disabled)]">
                 No employees found
               </div>
             ) : (
               (employees?.data || []).map((employee: Employee) => (
                 <div
                   key={employee.id}
-                  className="flex items-center justify-between p-3 bg-gray-50 rounded cursor-pointer hover:bg-gray-100"
+                  className="flex items-center justify-between p-3 rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] cursor-pointer hover:bg-[var(--c-surface-3)]"
                   onClick={() => {
                     setSelected(employee);
                     setDetailOpen(true);
@@ -471,11 +471,11 @@ export default function PayrollDashboard() {
                 >
                   <div className="flex-1">
                     <div className="font-medium">{employee.name}</div>
-                    <div className="text-sm text-gray-600">
+                    <div className="text-sm text-[var(--c-text-subtle)]">
                       {employee.title}
                     </div>
                     {employee.created_at && (
-                      <div className="text-xs text-gray-500">
+                      <div className="text-xs text-[var(--c-text-disabled)]">
                         {employee.department || "General"} • Started{" "}
                         {formatDate(employee.created_at)}
                       </div>

--- a/frontend/src/components/risk/risk-dashboard.tsx
+++ b/frontend/src/components/risk/risk-dashboard.tsx
@@ -17,6 +17,9 @@ import {
   XCircle
 } from 'lucide-react'
 
+/**
+ * Dashboard presenting risk metrics and alerts for the selected company.
+ */
 export default function RiskDashboard() {
   const { companyId } = useCompany()
 
@@ -130,8 +133,8 @@ export default function RiskDashboard() {
           {[...Array(3)].map((_, i) => (
             <Card key={i} className="animate-pulse">
               <CardHeader>
-                <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-                <div className="h-8 bg-gray-200 rounded w-1/2"></div>
+                <div className="h-4 rounded w-3/4 bg-[var(--c-surface-3)]"></div>
+                <div className="h-8 rounded w-1/2 bg-[var(--c-surface-3)]"></div>
               </CardHeader>
             </Card>
           ))}
@@ -140,15 +143,19 @@ export default function RiskDashboard() {
     )
   }
 
-  const riskLevelColor = riskStatus?.overallRisk === 'high' ? 'text-red-600' : 
-                       riskStatus?.overallRisk === 'medium' ? 'text-yellow-600' : 'text-green-600'
+  const riskLevelColor =
+    riskStatus?.overallRisk === 'high'
+      ? 'text-[var(--c-error)]'
+      : riskStatus?.overallRisk === 'medium'
+      ? 'text-[var(--c-warning)]'
+      : 'text-[var(--c-success)]'
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Risk Analysis</h1>
-          <p className="text-gray-600">Monitor and assess financial risks</p>
+          <h1 className="text-2xl font-bold text-[var(--c-text)]">Risk Analysis</h1>
+          <p className="text-[var(--c-text-subtle)]">Monitor and assess financial risks</p>
         </div>
         <Button 
           onClick={triggerAssessment} 
@@ -171,7 +178,7 @@ export default function RiskDashboard() {
             <div className={`text-2xl font-bold ${riskLevelColor}`}>
               {riskStatus?.overallRisk?.charAt(0).toUpperCase() + riskStatus?.overallRisk?.slice(1)}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               Risk Score: {riskStatus?.score}/100
             </p>
           </CardContent>
@@ -186,7 +193,7 @@ export default function RiskDashboard() {
             <div className="text-2xl font-bold text-yellow-600">
               {alerts.filter(a => !a.acknowledged).length}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               Unacknowledged alerts
             </p>
           </CardContent>
@@ -201,7 +208,7 @@ export default function RiskDashboard() {
             <div className="text-2xl font-bold text-blue-600">
               {riskStatus?.lastAssessment ? formatDateTime(riskStatus.lastAssessment).split(',')[0] : 'N/A'}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
+            <p className="text-xs text-[var(--c-text-subtle)] mt-1">
               {riskStatus?.lastAssessment ? formatDateTime(riskStatus.lastAssessment).split(',')[1] : 'No recent assessment'}
             </p>
           </CardContent>
@@ -219,10 +226,13 @@ export default function RiskDashboard() {
         <CardContent>
           <div className="space-y-4">
             {riskStatus?.factors?.map((factor: any, index: number) => (
-              <div key={index} className="flex items-center justify-between p-3 bg-gray-50 rounded">
+              <div
+                key={index}
+                className="flex items-center justify-between p-3 rounded border border-[var(--c-border)] bg-[var(--c-surface-1)]"
+              >
                 <div>
                   <div className="font-medium">{factor.category}</div>
-                  <div className="text-sm text-gray-600">Impact: {factor.impact}</div>
+                  <div className="text-sm text-[var(--c-text-subtle)]">Impact: {factor.impact}</div>
                 </div>
                 <div className="text-right">
                   <div className="font-semibold">{factor.score}/100</div>
@@ -247,30 +257,33 @@ export default function RiskDashboard() {
         <CardContent>
           <div className="space-y-4">
             {alerts.length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
+              <div className="py-8 text-center text-[var(--c-text-disabled)]">
                 No active alerts
               </div>
             ) : (
               alerts.map((alert) => (
-                <div key={alert.id} className="flex items-start justify-between p-4 border rounded">
+                <div
+                  key={alert.id}
+                  className="flex items-start justify-between p-4 border border-[var(--c-border)] rounded bg-[var(--c-surface-1)]"
+                >
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-1">
                       <div className={`px-2 py-1 text-xs rounded ${getRiskColor(alert.level)}`}>
                         {alert.level}
                       </div>
-                      <div className="text-xs text-gray-500">
+                      <div className="text-xs text-[var(--c-text-disabled)]">
                         {alert.type.replace('_', ' ')}
                       </div>
                     </div>
                     <div className="font-medium">{alert.title}</div>
-                    <div className="text-sm text-gray-600 mt-1">{alert.description}</div>
-                    <div className="text-xs text-gray-500 mt-2">
+                    <div className="text-sm text-[var(--c-text-subtle)] mt-1">{alert.description}</div>
+                    <div className="text-xs text-[var(--c-text-disabled)] mt-2">
                       {formatDateTime(alert.timestamp)}
                     </div>
                   </div>
                   <div className="flex items-center gap-2 ml-4">
                     {alert.acknowledged ? (
-                      <CheckCircle className="h-5 w-5 text-green-600" />
+                      <CheckCircle className="h-5 w-5 text-[var(--c-success)]" />
                     ) : (
                       <Button
                         size="sm"

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -3,19 +3,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@frontend/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--c-accent)/60] disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-slate-900 text-slate-50 hover:bg-slate-900/90",
+        default: "bg-[var(--c-accent)] text-white hover:bg-[var(--c-accent-hover)]",
         destructive:
-          "bg-red-500 text-slate-50 hover:bg-red-500/90",
+          "bg-[var(--c-error)] text-white hover:bg-[var(--c-error-hover)]",
         outline:
-          "border border-slate-200 bg-white hover:bg-slate-100 hover:text-slate-900",
+          "border border-[var(--c-border)] bg-[var(--c-surface-1)] hover:bg-[var(--c-surface-3)] text-[var(--c-text)]",
         secondary:
-          "bg-slate-100 text-slate-900 hover:bg-slate-100/80",
-        ghost: "hover:bg-slate-100 hover:text-slate-900",
-        link: "text-slate-900 underline-offset-4 hover:underline",
+          "bg-[var(--c-surface-2)] text-[var(--c-text)] hover:bg-[var(--c-surface-3)]",
+        ghost: "hover:bg-[var(--c-surface-3)] text-[var(--c-text)]",
+        link: "text-[var(--c-accent)] underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border border-gray-200 bg-white text-gray-950 shadow-sm",
+      "rounded-lg border border-[var(--c-border)] bg-[var(--c-surface-1)] text-[var(--c-text)] shadow-sm",
       className
     )}
     {...props}
@@ -49,7 +49,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-gray-600", className)}
+    className={cn("text-sm text-[var(--c-text-subtle)]", className)}
     {...props}
   />
 ))

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -12,11 +12,11 @@ export const DialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Portal>
-    <DialogPrimitive.Overlay className="fixed inset-0 bg-black/40" />
+    <DialogPrimitive.Overlay className="fixed inset-0 bg-[var(--c-overlay)]" />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-1/2 top-1/2 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-md bg-white p-6 shadow',
+        'fixed left-1/2 top-1/2 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-md border border-[var(--c-border)] bg-[var(--c-surface-2)] p-6 shadow-[0_2px_8px_rgba(13,17,23,.60)]',
         'focus:outline-none',
         className
       )}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -37,13 +37,13 @@ export function formatPercentage(value: number): string {
 export function getRiskColor(level: 'low' | 'medium' | 'high'): string {
   switch (level) {
     case 'low':
-      return 'text-green-600 bg-green-50'
+      return 'text-[var(--c-success)] bg-[var(--c-surface-3)]'
     case 'medium':
-      return 'text-yellow-600 bg-yellow-50'
+      return 'text-[var(--c-warning)] bg-[var(--c-surface-3)]'
     case 'high':
-      return 'text-red-600 bg-red-50'
+      return 'text-[var(--c-error)] bg-[var(--c-surface-3)]'
     default:
-      return 'text-gray-600 bg-gray-50'
+      return 'text-[var(--c-text-subtle)] bg-[var(--c-surface-3)]'
   }
 }
 
@@ -53,15 +53,15 @@ export function getStatusColor(status: string): string {
     case 'healthy':
     case 'connected':
     case 'approved':
-      return 'text-green-600 bg-green-50'
+      return 'text-[var(--c-success)] bg-[var(--c-surface-3)]'
     case 'pending':
     case 'processing':
-      return 'text-yellow-600 bg-yellow-50'
+      return 'text-[var(--c-warning)] bg-[var(--c-surface-3)]'
     case 'error':
     case 'failed':
     case 'disconnected':
-      return 'text-red-600 bg-red-50'
+      return 'text-[var(--c-error)] bg-[var(--c-surface-3)]'
     default:
-      return 'text-gray-600 bg-gray-50'
+      return 'text-[var(--c-text-subtle)] bg-[var(--c-surface-3)]'
   }
 }


### PR DESCRIPTION
## Summary
- add dark mode variables to globals.css
- apply dark theme palette to layout, buttons, cards, dialogs and sidebar
- update helpers to return dark-themed status classes

## Testing
- `pnpm lint` *(fails: numerous existing lint errors)*
- `pnpm test --coverage` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687da74187c8832899e3998a61c4135b