### PR TITLE
feat: extend employee and payroll entry schema

### DIFF
--- a/backend/migrations/001_initial.sql
+++ b/backend/migrations/001_initial.sql
@@ -26,7 +26,8 @@ CREATE TABLE IF NOT EXISTS employees (
   department       TEXT,
   annual_salary    NUMERIC(10,2),
   hourly_rate      NUMERIC(8,2),
-  is_active        BOOLEAN DEFAULT TRUE,
+  -- Employment status from source CSV (e.g. 'Active', 'Inactive')
+  employee_status  TEXT DEFAULT 'Active',
   created_at       TIMESTAMPTZ DEFAULT NOW(),
   updated_at       TIMESTAMPTZ DEFAULT NOW()
 );
@@ -117,7 +118,7 @@ CREATE TABLE IF NOT EXISTS alerts (
 /*──────────────────────  INDEXES  ──────────────────────*/
 
 CREATE INDEX IF NOT EXISTS idx_employees_company_id          ON employees(company_id);
-CREATE INDEX IF NOT EXISTS idx_employees_active              ON employees(is_active);
+CREATE INDEX IF NOT EXISTS idx_employees_status             ON employees(employee_status);
 
 CREATE INDEX IF NOT EXISTS idx_payroll_runs_company_id       ON payroll_runs(company_id);
 CREATE INDEX IF NOT EXISTS idx_payroll_runs_status           ON payroll_runs(status);

--- a/backend/migrations/20240729_extend_employee_payroll_entries.sql
+++ b/backend/migrations/20240729_extend_employee_payroll_entries.sql
@@ -1,0 +1,23 @@
+-- Extend employees with HR metadata
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS business_unit_code TEXT;
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS business_unit_name TEXT;
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS date_of_birth DATE;
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS date_of_joining DATE;
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS employment_category TEXT;
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS grade TEXT;
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS designation TEXT;
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS continent TEXT;
+-- Replace legacy is_active flag with employee_status from CSV
+ALTER TABLE employees DROP COLUMN IF EXISTS is_active;
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS employee_status TEXT DEFAULT 'Active';
+DROP INDEX IF EXISTS idx_employees_active;
+CREATE INDEX IF NOT EXISTS idx_employees_status ON employees(employee_status);
+
+-- Extend payroll_entries with salary breakdown
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS basic_salary NUMERIC(10,2) DEFAULT 0;
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS allowance NUMERIC(10,2) DEFAULT 0;
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS statutory_bonus NUMERIC(10,2) DEFAULT 0;
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS total_deductions NUMERIC(10,2) DEFAULT 0;
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS net_salary NUMERIC(10,2) DEFAULT 0;
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS tax_spend NUMERIC(10,2) DEFAULT 0;
+ALTER TABLE payroll_entries ADD COLUMN IF NOT EXISTS reimbursement_paid NUMERIC(10,2) DEFAULT 0;

--- a/backend/src/db/database.types.ts
+++ b/backend/src/db/database.types.ts
@@ -1,7 +1,3 @@
-
-> warp-sentinel-backend@1.0.0 env:backend
-> cross-env DOTENV_CONFIG_PATH=.env NODE_OPTIONS="--require dotenv/config" supabase gen types typescript --schema public --linked
-
 export type Json =
   | string
   | number
@@ -195,8 +191,16 @@ export type Database = {
           first_name: string
           hourly_rate: number | null
           id: string
-          is_active: boolean | null
+          employee_status: string | null
           last_name: string
+          business_unit_code: string | null
+          business_unit_name: string | null
+          date_of_birth: string | null
+          date_of_joining: string | null
+          employment_category: string | null
+          grade: string | null
+          designation: string | null
+          continent: string | null
           title: string | null
           updated_at: string | null
         }
@@ -210,8 +214,16 @@ export type Database = {
           first_name: string
           hourly_rate?: number | null
           id?: string
-          is_active?: boolean | null
+          employee_status?: string | null
           last_name: string
+          business_unit_code?: string | null
+          business_unit_name?: string | null
+          date_of_birth?: string | null
+          date_of_joining?: string | null
+          employment_category?: string | null
+          grade?: string | null
+          designation?: string | null
+          continent?: string | null
           title?: string | null
           updated_at?: string | null
         }
@@ -225,8 +237,16 @@ export type Database = {
           first_name?: string
           hourly_rate?: number | null
           id?: string
-          is_active?: boolean | null
+          employee_status?: string | null
           last_name?: string
+          business_unit_code?: string | null
+          business_unit_name?: string | null
+          date_of_birth?: string | null
+          date_of_joining?: string | null
+          employment_category?: string | null
+          grade?: string | null
+          designation?: string | null
+          continent?: string | null
           title?: string | null
           updated_at?: string | null
         }
@@ -252,6 +272,13 @@ export type Database = {
           payroll_run_id: string | null
           status: string | null
           taxes: number | null
+          basic_salary: number | null
+          allowance: number | null
+          statutory_bonus: number | null
+          total_deductions: number | null
+          net_salary: number | null
+          tax_spend: number | null
+          reimbursement_paid: number | null
           updated_at: string | null
         }
         Insert: {
@@ -265,6 +292,13 @@ export type Database = {
           payroll_run_id?: string | null
           status?: string | null
           taxes?: number | null
+          basic_salary?: number | null
+          allowance?: number | null
+          statutory_bonus?: number | null
+          total_deductions?: number | null
+          net_salary?: number | null
+          tax_spend?: number | null
+          reimbursement_paid?: number | null
           updated_at?: string | null
         }
         Update: {
@@ -278,6 +312,13 @@ export type Database = {
           payroll_run_id?: string | null
           status?: string | null
           taxes?: number | null
+          basic_salary?: number | null
+          allowance?: number | null
+          statutory_bonus?: number | null
+          total_deductions?: number | null
+          net_salary?: number | null
+          tax_spend?: number | null
+          reimbursement_paid?: number | null
           updated_at?: string | null
         }
         Relationships: [

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -26,7 +26,17 @@ CREATE TABLE IF NOT EXISTS employees (
   department       TEXT,
   annual_salary    NUMERIC(10,2),
   hourly_rate      NUMERIC(8,2),
-  is_active        BOOLEAN DEFAULT TRUE,
+  -- HR metadata
+  business_unit_code TEXT,
+  business_unit_name TEXT,
+  date_of_birth    DATE,
+  date_of_joining  DATE,
+  employment_category TEXT,
+  grade            TEXT,
+  designation      TEXT,
+  continent        TEXT,
+  -- Employment status from source CSV (e.g. 'Active', 'Inactive')
+  employee_status  TEXT DEFAULT 'Active',
   created_at       TIMESTAMPTZ DEFAULT NOW(),
   updated_at       TIMESTAMPTZ DEFAULT NOW()
 );
@@ -59,6 +69,14 @@ CREATE TABLE IF NOT EXISTS payroll_entries (
   net_pay          NUMERIC(10,2) NOT NULL,
   taxes            NUMERIC(10,2) DEFAULT 0,
   deductions       NUMERIC(10,2) DEFAULT 0,
+  -- Salary components
+  basic_salary     NUMERIC(10,2) DEFAULT 0,
+  allowance        NUMERIC(10,2) DEFAULT 0,
+  statutory_bonus  NUMERIC(10,2) DEFAULT 0,
+  total_deductions NUMERIC(10,2) DEFAULT 0,
+  net_salary       NUMERIC(10,2) DEFAULT 0,
+  tax_spend        NUMERIC(10,2) DEFAULT 0,
+  reimbursement_paid NUMERIC(10,2) DEFAULT 0,
   hours            NUMERIC(6,2),
   status           TEXT DEFAULT 'pending'
                  CHECK (status IN ('pending','approved','processed','cancelled')),
@@ -116,7 +134,7 @@ CREATE TABLE IF NOT EXISTS alerts (
 /*──────────────────────  INDEXES  ──────────────────────*/
 
 CREATE INDEX IF NOT EXISTS idx_employees_company_id          ON employees(company_id);
-CREATE INDEX IF NOT EXISTS idx_employees_active              ON employees(is_active);
+CREATE INDEX IF NOT EXISTS idx_employees_status             ON employees(employee_status);
 
 CREATE INDEX IF NOT EXISTS idx_payroll_runs_company_id       ON payroll_runs(company_id);
 CREATE INDEX IF NOT EXISTS idx_payroll_runs_status           ON payroll_runs(status);

--- a/backend/src/db/seed.sql
+++ b/backend/src/db/seed.sql
@@ -6,15 +6,33 @@ ON CONFLICT (id) DO NOTHING;
 -- Insert demo employees
 INSERT INTO employees (id, company_id, employee_number,
                        first_name, last_name, email, title, department,
-                       annual_salary, is_active)
+                       annual_salary, employee_status,
+                       business_unit_code, business_unit_name, date_of_birth, date_of_joining,
+                       employment_category, grade, designation, continent)
 VALUES
   ('550e8400-e29b-41d4-a716-446655440001',
    '550e8400-e29b-41d4-a716-446655440000', 'EMP001',
-   'Vishal','Patel','vishal@payroll-sentinel.com','Software Engineer','Engineering',333333,TRUE),
+   'Vishal','Patel','vishal@payroll-sentinel.com','Software Engineer','Engineering',333333,'Inactive',
+   'BU01','Engineering','1990-01-01','2020-06-15','Full-Time','S1','Engineer','North America'),
   ('550e8400-e29b-41d4-a716-446655440002',
    '550e8400-e29b-41d4-a716-446655440000', 'EMP002',
-   'V','Money','vmoney@payroll-sentinel.com','CEO','Founder',999999,TRUE),
+   'V','Money','vmoney@payroll-sentinel.com','CEO','Founder',999999,'Active',
+   'BU02','Executive','1985-05-20','2018-01-10','Full-Time','E1','Chief Executive','North America'),
   ('550e8400-e29b-41d4-a716-446655440003',
    '550e8400-e29b-41d4-a716-446655440000', 'EMP003',
-   'vish','pat','chiefvishpat@payroll-sentinel.com','Creative Director','Creativity',132137,TRUE)
+   'vish','pat','chiefvishpat@payroll-sentinel.com','Creative Director','Creativity',132137,'Active',
+   'BU03','Creative','1992-09-09','2021-03-01','Contractor','C1','Director','Europe')
+ON CONFLICT (id) DO NOTHING;
+
+-- Seed a demo payroll run and entry showcasing salary components
+INSERT INTO payroll_runs (id, company_id, run_number, pay_period_start, pay_period_end, pay_date, status, total_gross, total_net, total_taxes, total_deductions, employee_count)
+VALUES ('550e8400-e29b-41d4-a716-446655440100', '550e8400-e29b-41d4-a716-446655440000', 'RUN001',
+        '2024-07-01', '2024-07-15', '2024-07-20', 'processed', 1400000, 104500, 20000, 10000, 1)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO payroll_entries (id, payroll_run_id, employee_id, gross_pay, net_pay, taxes, deductions,
+                            basic_salary, allowance, statutory_bonus, total_deductions, net_salary, tax_spend, reimbursement_paid)
+VALUES ('550e8400-e29b-41d4-a716-446655440101', '550e8400-e29b-41d4-a716-446655440100',
+        '550e8400-e29b-41d4-a716-446655440001', 1400000, 104500, 20000, 10000,
+        55725.24, 4785.05, 23508.9, 10000, 104500, 1251116, 3885797)
 ON CONFLICT (id) DO NOTHING;

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -28,7 +28,16 @@ export interface Employee {
   department?: string;
   annual_salary?: number;
   hourly_rate?: number;
-  is_active: boolean;
+  business_unit_code?: string;
+  business_unit_name?: string;
+  date_of_birth?: string;
+  date_of_joining?: string;
+  employment_category?: string;
+  grade?: string;
+  designation?: string;
+  continent?: string;
+  /** Employment status from CSV (e.g., 'Active') */
+  employee_status?: string;
   created_at: string;
   updated_at: string;
 }
@@ -58,6 +67,13 @@ export interface PayrollEntry {
   net_pay: number;
   taxes: number;
   deductions: number;
+  basic_salary?: number;
+  allowance?: number;
+  statutory_bonus?: number;
+  total_deductions?: number;
+  net_salary?: number;
+  tax_spend?: number;
+  reimbursement_paid?: number;
   hours?: number;
   status: 'pending' | 'approved' | 'processed' | 'cancelled';
   created_at: string;
@@ -68,9 +84,7 @@ export interface PayrollEntry {
    interfaces stay as-is — clip for brevity */
 
 export interface CreateEmployeeInput
-  extends Omit<Employee, 'id' | 'created_at' | 'updated_at' | 'is_active'> {
-  is_active?: boolean;
-}
+  extends Omit<Employee, 'id' | 'created_at' | 'updated_at'> {}
 
 export interface CreatePayrollRunInput
   extends Pick<
@@ -89,5 +103,12 @@ export interface CreatePayrollEntryInput
   > {
   taxes?: number;
   deductions?: number;
+  basic_salary?: number;
+  allowance?: number;
+  statutory_bonus?: number;
+  total_deductions?: number;
+  net_salary?: number;
+  tax_spend?: number;
+  reimbursement_paid?: number;
   status?: PayrollEntry['status'];
 }

--- a/backend/src/routes/mock-data.ts
+++ b/backend/src/routes/mock-data.ts
@@ -222,7 +222,7 @@ async function mockDataRoutes(fastify: FastifyInstance) {
           email: 'john.smith@' + companyName.toLowerCase().replace(/\s+/g, '') + '.com',
           department: 'Engineering',
           annual_salary: 75000,
-          is_active: true
+          employee_status: 'Active'
         },
         {
           id: '550e8400-e29b-41d4-a716-446655440002',
@@ -233,7 +233,7 @@ async function mockDataRoutes(fastify: FastifyInstance) {
           email: 'jane.doe@' + companyName.toLowerCase().replace(/\s+/g, '') + '.com',
           department: 'Marketing',
           annual_salary: 65000,
-          is_active: true
+          employee_status: 'Active'
         },
         {
           id: '550e8400-e29b-41d4-a716-446655440003',
@@ -244,7 +244,7 @@ async function mockDataRoutes(fastify: FastifyInstance) {
           email: 'bob.johnson@' + companyName.toLowerCase().replace(/\s+/g, '') + '.com',
           department: 'Operations',
           annual_salary: 70000,
-          is_active: true
+          employee_status: 'Active'
         }
       ];
       

--- a/backend/src/services/database/check.ts
+++ b/backend/src/services/database/check.ts
@@ -14,7 +14,7 @@ interface DatabaseEmployee {
   department: string;
   annual_salary?: number;
   hourly_rate?: number;
-  is_active: boolean;
+  employee_status: string;
   created_at: string;
   updated_at: string;
 }
@@ -75,7 +75,8 @@ export class DatabaseCheckService extends BaseDatabaseService {
 
     const dbFilters: any = {};
     if (filters.companyId) dbFilters.company_id = filters.companyId;
-    if (filters.active !== undefined) dbFilters.is_active = filters.active;
+    if (filters.active !== undefined)
+      dbFilters.employee_status = filters.active ? 'Active' : 'Inactive';
     if (filters.department) dbFilters.department = filters.department;
 
     const result = await this.findMany<DatabaseEmployee>(
@@ -102,7 +103,7 @@ export class DatabaseCheckService extends BaseDatabaseService {
         department: emp.department,
         annualSalary: emp.annual_salary,
         hourlyRate: emp.hourly_rate,
-        isActive: emp.is_active,
+        isActive: emp.employee_status === 'Active',
       })),
       total: (result.data as any).total
     };
@@ -668,7 +669,7 @@ export class DatabaseCheckService extends BaseDatabaseService {
         department: emp.department,
         annualSalary: emp.annual_salary,
         hourlyRate: emp.hourly_rate,
-        isActive: emp.is_active,
+        isActive: emp.employee_status === 'Active',
       },
       metadata: result.metadata || {
         requestId: this.generateRequestId(),

--- a/frontend/src/components/data/employee-uploader.tsx
+++ b/frontend/src/components/data/employee-uploader.tsx
@@ -16,7 +16,7 @@ interface Employee {
   position: string
   department: string
   salary: number
-  status: 'active' | 'inactive'
+  employee_status: 'active' | 'inactive'
 }
 
 export default function EmployeeUploader({ onSuccess }: EmployeeUploaderProps) {
@@ -27,7 +27,7 @@ export default function EmployeeUploader({ onSuccess }: EmployeeUploaderProps) {
       position: '',
       department: '',
       salary: 0,
-      status: 'active'
+      employee_status: 'active'
     }
   ])
   const [isUploading, setIsUploading] = useState(false)
@@ -40,7 +40,7 @@ export default function EmployeeUploader({ onSuccess }: EmployeeUploaderProps) {
       position: '',
       department: '',
       salary: 0,
-      status: 'active'
+      employee_status: 'active'
     }])
   }
 
@@ -62,7 +62,7 @@ export default function EmployeeUploader({ onSuccess }: EmployeeUploaderProps) {
         position: 'Software Engineer',
         department: 'Engineering',
         salary: 85000,
-        status: 'active'
+        employee_status: 'active'
       },
       {
         name: 'Jane Smith',
@@ -70,7 +70,7 @@ export default function EmployeeUploader({ onSuccess }: EmployeeUploaderProps) {
         position: 'Product Manager',
         department: 'Product',
         salary: 95000,
-        status: 'active'
+        employee_status: 'active'
       },
       {
         name: 'Mike Johnson',
@@ -78,7 +78,7 @@ export default function EmployeeUploader({ onSuccess }: EmployeeUploaderProps) {
         position: 'UX Designer',
         department: 'Design',
         salary: 75000,
-        status: 'active'
+        employee_status: 'active'
       },
       {
         name: 'Sarah Wilson',
@@ -86,7 +86,7 @@ export default function EmployeeUploader({ onSuccess }: EmployeeUploaderProps) {
         position: 'Marketing Manager',
         department: 'Marketing',
         salary: 70000,
-        status: 'active'
+        employee_status: 'active'
       }
     ]
     setEmployees(sampleEmployees)

--- a/frontend/src/components/payroll/employee-detail-panel.tsx
+++ b/frontend/src/components/payroll/employee-detail-panel.tsx
@@ -27,7 +27,7 @@ export default function EmployeeDetailPanel({
   const [title, setTitle] = useState(employee.title)
   const [department, setDepartment] = useState(employee.department || '')
   const [salary, setSalary] = useState(employee.salary)
-  const [status, setStatus] = useState(employee.status)
+  const [employeeStatus, setEmployeeStatus] = useState(employee.employee_status)
   const [loading, setLoading] = useState(false)
 
   // Refresh employee details when opened so the panel shows latest data
@@ -40,7 +40,7 @@ export default function EmployeeDetailPanel({
         setTitle(e.title)
         setDepartment(e.department || '')
         setSalary(e.salary)
-        setStatus(e.status)
+        setEmployeeStatus(e.employee_status)
       })
       .catch(err => console.error('fetch employee detail failed', err))
   }, [open, employee.id, companyId])
@@ -51,7 +51,7 @@ export default function EmployeeDetailPanel({
     try {
       await api.payroll.updateEmployee(
         employee.id,
-        { title, salary, status, department },
+        { title, salary, employee_status: employeeStatus, department },
         companyId || undefined
       )
       setEditMode(false)
@@ -128,8 +128,8 @@ export default function EmployeeDetailPanel({
               required
             />
             <select
-              value={status}
-              onChange={e => setStatus(e.target.value)}
+              value={employeeStatus}
+              onChange={e => setEmployeeStatus(e.target.value)}
               className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
             >
               <option value="active">active</option>
@@ -149,7 +149,7 @@ export default function EmployeeDetailPanel({
               <div>{employee.title || '-'}</div>
               <div>{employee.department || '-'}</div>
               <div>Salary: ${employee.salary.toLocaleString()}</div>
-              <div>Status: {employee.status}</div>
+              <div>Status: {employee.employee_status}</div>
             </div>
             <div className="flex gap-2 mt-4">
               <Button size="sm" onClick={() => {console.debug(`[Payroll] EDIT employee ${employee.name}`); setEditMode(true) }}>Edit</Button>

--- a/frontend/src/components/payroll/payroll-dashboard.tsx
+++ b/frontend/src/components/payroll/payroll-dashboard.tsx
@@ -194,7 +194,7 @@ export default function PayrollDashboard() {
                     name: formData.get("name"),
                     title: formData.get("title"),
                     salary: Number(formData.get("salary") || 0),
-                    status: formData.get("status"),
+                    employee_status: formData.get("employee_status"),
                     department: formData.get("department"),
                   });
                   await Promise.all([mutEmp(), mutSum()]);
@@ -241,7 +241,7 @@ export default function PayrollDashboard() {
                   required
                 />
                 <select
-                  name="status"
+                  name="employee_status"
                   className="w-full rounded border border-[var(--c-border)] bg-[var(--c-surface-1)] p-2 text-[var(--c-text)]"
                 >
                   <option value="active">active</option>
@@ -486,9 +486,9 @@ export default function PayrollDashboard() {
                       {formatCurrency(employee.salary)}
                     </div>
                     <div
-                      className={`text-sm px-2 py-1 rounded ${getStatusColor(employee.status)}`}
+                      className={`text-sm px-2 py-1 rounded ${getStatusColor(employee.employee_status)}`}
                     >
-                      {employee.status}
+                      {employee.employee_status}
                     </div>
                   </div>
                 </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -75,7 +75,7 @@ export interface Employee {
   name: string
   title: string
   salary: number
-  status: 'active' | 'inactive'
+  employee_status: 'active' | 'inactive'
   department?: string
 }
 

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared DTOs for Payroll Sentinel Demo
+ */
+/**
+ * Company record
+ */
 export interface Company {
     id: string;
     name: string;
@@ -7,6 +13,9 @@ export interface Company {
     created_at: string;
     updated_at: string;
 }
+/**
+ * Linked bank account via Plaid
+ */
 export interface BankAccount {
     id: string;
     company_id: string;
@@ -19,19 +28,40 @@ export interface BankAccount {
     created_at: string;
     updated_at: string;
 }
+/**
+ * Payroll run result
+ */
 export interface PayrollRun {
-    payrollRunId: string;
-    status: 'pending' | 'paid' | string;
+    id: string;
+    company_id: string;
+    check_payroll_id: string;
+    run_number: string;
+    pay_period_start: string;
+    pay_period_end: string;
+    pay_date: string;
+    status: "draft" | "pending" | "approved" | "processed" | "cancelled";
+    total_gross: number;
+    total_net: number;
+    total_taxes: number;
+    total_deductions: number;
+    employee_count: number;
     created_at?: string;
+    updated_at?: string;
 }
+/**
+ * Pay schedule configuration
+ */
 export interface PaySchedule {
     id: string;
     companyId: string;
-    frequency: 'weekly' | 'biweekly' | 'semimonthly' | 'monthly';
+    frequency: "weekly" | "biweekly" | "semimonthly" | "monthly";
     firstPayday: string;
     isActive: boolean;
     created_at: string;
 }
+/**
+ * Bank account balance from Plaid
+ */
 export interface AccountBalance {
     accountId: string;
     current: number;
@@ -39,14 +69,73 @@ export interface AccountBalance {
     currencyCode: string;
     lastUpdated: string;
 }
+/**
+ * Plaid Link Token response
+ */
 export interface LinkTokenResponse {
     linkToken: string;
     expiration: string;
     requestId: string;
 }
+/**
+ * Plaid Access Token response
+ */
 export interface AccessTokenResponse {
     accessToken: string;
     itemId: string;
     requestId: string;
 }
-//# sourceMappingURL=types.d.ts.map
+/**
+ * Employee record
+ */
+export interface Employee {
+    id: string;
+    company_id: string;
+    name: string;
+    title: string;
+    salary: number;
+    employee_status: string;
+    department?: string | null;
+    business_unit_code?: string | null;
+    business_unit_name?: string | null;
+    date_of_birth?: string | null;
+    date_of_joining?: string | null;
+    employment_category?: string | null;
+    grade?: string | null;
+    designation?: string | null;
+    continent?: string | null;
+    created_at?: string;
+    updated_at?: string;
+}
+/**
+ * Detailed payroll entry with salary components
+ */
+export interface PayrollEntry {
+    id: string;
+    payroll_run_id: string;
+    employee_id: string;
+    gross_pay: number;
+    net_pay: number;
+    taxes: number;
+    deductions: number;
+    basic_salary?: number;
+    allowance?: number;
+    statutory_bonus?: number;
+    total_deductions?: number;
+    net_salary?: number;
+    tax_spend?: number;
+    reimbursement_paid?: number;
+    hours?: number;
+    status: string;
+    created_at?: string;
+    updated_at?: string;
+}
+/**
+ * Dashboard payroll summary
+ */
+export interface PayrollSummary {
+    totalEmployees: number;
+    monthlyPayroll: number;
+    nextPayroll: string | null;
+    pendingRuns: number;
+}

--- a/shared/types.js
+++ b/shared/types.js
@@ -1,3 +1,5 @@
 "use strict";
+/**
+ * Shared DTOs for Payroll Sentinel Demo
+ */
 Object.defineProperty(exports, "__esModule", { value: true });
-//# sourceMappingURL=types.js.map

--- a/shared/types.js.map
+++ b/shared/types.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"types.js","sourceRoot":"","sources":["types.ts"],"names":[],"mappings":""}
+{"version":3,"file":"types.js","sourceRoot":"","sources":["types.ts"],"names":[],"mappings":";AAAA;;GAEG"}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -102,8 +102,40 @@ export interface Employee {
   name: string;
   title: string;
   salary: number;
-  status: string;
+  employee_status: string;
   department?: string | null;
+  business_unit_code?: string | null;
+  business_unit_name?: string | null;
+  date_of_birth?: string | null;
+  date_of_joining?: string | null;
+  employment_category?: string | null;
+  grade?: string | null;
+  designation?: string | null;
+  continent?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/**
+ * Detailed payroll entry with salary components
+ */
+export interface PayrollEntry {
+  id: string;
+  payroll_run_id: string;
+  employee_id: string;
+  gross_pay: number;
+  net_pay: number;
+  taxes: number;
+  deductions: number;
+  basic_salary?: number;
+  allowance?: number;
+  statutory_bonus?: number;
+  total_deductions?: number;
+  net_salary?: number;
+  tax_spend?: number;
+  reimbursement_paid?: number;
+  hours?: number;
+  status: string;
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## Summary
- align employee records with CSV column naming by replacing `is_active` with `employee_status` throughout schema, migrations, types and routes
- seed demo payroll run and entry showing salary breakdown fields
- propagate `employee_status` field through shared types and front-end components

## Testing
- `pnpm lint` *(fails: numerous lint errors and hook order issues)*
- `pnpm test --coverage` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc79ebd588328a005badac72100b3